### PR TITLE
Add support for OpenBSD.

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -19,7 +19,6 @@ class ldap::params {
   $server_service_ensure      = 'running'
   $server_service_manage      = true
   $server_config_template     = 'ldap/slapd.conf.erb'
-  $server_directory           = '/var/lib/ldap'
   $server_db_config_file      = "${server_directory}/DB_CONFIG"
   $server_db_config_template  = 'ldap/DB_CONFIG.erb'
 
@@ -61,12 +60,35 @@ class ldap::params {
 
       $pidfile                 = '/var/run/slapd/slapd.pid'
       $argsfile                = '/var/run/slapd/slapd.args'
+      $ldapowner               = '0'
+      $ldapgroup               = '0'
 
       $server_package_name     = 'slapd'
       $server_service_name     = 'slapd'
       $server_config_file      = "${ldap_config_directory}/slapd.conf"
       $server_default_file     = "${os_config_directory}/slapd"
       $server_default_template = 'ldap/debian/defaults.erb'
+      $server_directory        = '/var/lib/ldap'
+      $gem_name                = 'net-ldap'
+    }
+    'OpenBSD': {
+      $ldap_config_directory   = '/etc/openldap'
+      $os_config_directory     = undef
+
+      $client_package_name     = 'openldap-client'
+      $client_config_file      = "${ldap_config_directory}/ldap.conf"
+
+      $pidfile                 = '/var/run/openldap/slapd.pid'
+      $argsfile                = '/var/run/openldap/slapd.args'
+      $ldapowner               = '_openldap'
+      $ldapgroup               = '_openldap'
+
+      $server_package_name     = 'openldap-server'
+      $server_service_name     = 'slapd'
+      $server_config_file      = "${ldap_config_directory}/slapd.conf"
+      $server_default_file     = undef
+      $server_default_template = undef
+      $server_directory        = '/var/openldap-data'
       $gem_name                = 'net-ldap'
     }
     'RedHat': {
@@ -75,6 +97,8 @@ class ldap::params {
 
       $client_package_name     = 'openldap-clients'
       $client_config_file      = "${ldap_config_directory}/ldap.conf"
+      $ldapowner               = '0'
+      $ldapgroup               = '0'
 
       $pidfile                 = '/var/run/openldap/slapd.pid'
       $argsfile                = '/var/run/openldap/slapd.args'
@@ -84,6 +108,7 @@ class ldap::params {
       $server_config_file      = "${ldap_config_directory}/slapd.conf"
       $server_default_file     = "${os_config_directory}/ldap"
       $server_default_template = 'ldap/redhat/sysconfig.erb'
+      $server_directory        = '/var/lib/ldap'
       $gem_name                = 'net-ldap'
     }
     default: {

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -16,6 +16,12 @@
 # [*directory*]
 #   Path to where the slapd database files should be stored.
 #
+# [*ldapowner*]
+#   The owner of the slapd and database configuration files.
+#
+# [*ldapgroup*]
+#   The group of the slapd and database configuration files.
+#
 # [*log_level*]
 #   Daemon logging level, see http://www.openldap.org/doc/admin24/slapdconfig.html.
 #
@@ -115,6 +121,8 @@ class ldap::server (
   $db_config_template = $ldap::params::server_db_config_template,
   $gem_name         = $ldap::params::gem_name,
   $gem_ensure       = $ldap::params::gem_ensure,
+  $ldapowner        = $ldap::params::ldapowner,
+  $ldapgroup        = $ldap::params::ldapgroup,
 ) inherits ldap::params {
 
   include stdlib

--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -4,22 +4,24 @@
 #
 class ldap::server::config inherits ldap::server {
   file { $ldap::server::config_file:
-    owner   => 0,
-    group   => 0,
+    owner   => $ldap::server::ldapowner,
+    group   => $ldap::server::ldapgroup,
     mode    => '0644',
     content => template($ldap::server::config_template),
   }
 
-  file { $ldap::server::default_file:
-    owner   => 0,
-    group   => 0,
-    mode    => '0644',
-    content => template($ldap::server::default_template),
+  if $ldap::server::default_file {
+    file { $ldap::server::default_file:
+      owner   => 0,
+      group   => 0,
+      mode    => '0644',
+      content => template($ldap::server::default_template),
+    }
   }
 
   file { $ldap::server::db_config_file:
-    owner   => 0,
-    group   => 0,
+    owner   => $ldap::server::ldapowner,
+    group   => $ldap::server::ldapgroup,
     mode    => '0644',
     content => template($ldap::server::db_config_template),
   }

--- a/spec/unit/classes/ldap_client_spec.rb
+++ b/spec/unit/classes/ldap_client_spec.rb
@@ -65,6 +65,33 @@ describe 'ldap::client', :type => :class do
     )}
   end
 
+  context "on a OpenBSD OS" do
+    let :facts do
+      {
+        :osfamily               => 'OpenBSD',
+      }
+    end
+
+    it { should compile.with_all_deps }
+
+    it { should contain_package('ldap-client').with(
+      :ensure => 'present',
+      :name   => 'openldap-client'
+    )}
+
+    it { should contain_package('net-ldap').with(
+      :ensure   => 'present',
+      :name     => 'net-ldap',
+      :provider => 'gem'
+    )}
+
+    it { should contain_file('/etc/openldap/ldap.conf').with(
+      :owner   => '0',
+      :group   => '0',
+      :mode    => '0644'
+    )}
+  end
+
   context 'on all OSes' do
     let :facts do
       {

--- a/spec/unit/classes/ldap_server_spec.rb
+++ b/spec/unit/classes/ldap_server_spec.rb
@@ -78,6 +78,39 @@ describe 'ldap::server', :type => :class do
     )}
   end
 
+  context "on a OpenBSD OS" do
+    let :facts do
+      {
+        :osfamily               => 'OpenBSD',
+      }
+    end
+
+    it { should compile.with_all_deps }
+
+    it { should contain_package('ldap-server').with(
+      :ensure => 'present',
+      :name   => 'openldap-server'
+    )}
+
+    it { should contain_service('ldap-server').with(
+      :ensure => 'running',
+      :enable => true,
+      :name   => 'slapd'
+    )}
+
+    it { should contain_file('/etc/openldap/slapd.conf').with(
+      :owner   => '_openldap',
+      :group   => '_openldap',
+      :mode    => '0644'
+    )}
+
+    it { should_not contain_file('/etc/sysconfig/ldap').with(
+      :owner   => '0',
+      :group   => '0',
+      :mode    => '0644'
+    )}
+  end
+
   context 'on all OSes' do
     let :facts do
       {


### PR DESCRIPTION
Further allow to set the owner/group of the database and slapd.conf file
via parameters. Default values are given in params.pp. This is because
on OpenBSD, ldap owner/group is _openldap:_openldap. Further, change the
permissions of slapd.conf from 0644 to 0640. There can be sensitive
information in that file, i.e. the rootpw, and this should just not
be world readable.
