### PR TITLE
Fix propagating of configdn, configpw, monitordn, monitorpw into

### DIFF
--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -82,10 +82,10 @@ class ldap::server (
   $suffix,
   $rootdn,
   $rootpw,
-  $configdn         = $rootdn,
-  $configpw         = $rootpw,
-  $monitordn        = $rootdn,
-  $monitorpw        = $rootpw,
+  $configdn         = undef,
+  $configpw         = undef,
+  $monitordn        = undef,
+  $monitorpw        = undef,
   $directory        = $ldap::params::server_directory,
   $log_level        = $ldap::params::server_log_level,
   $schemas          = $ldap::params::server_schemas,
@@ -128,6 +128,42 @@ class ldap::server (
   validate_array($modules)
   validate_array($indexes)
   validate_array($overlays)
+
+  if $config {
+    if $configdn {
+      $substconfigdn = $configdn
+    } else {
+      $substconfigdn = $rootdn
+      $configdn_is_same_as_rootdn = true
+    }
+    if $configdn_is_same_as_rootdn {
+      $substconfigpw = undef
+    } else {
+      if $configpw {
+        $substconfigpw = $configpw
+      } else {
+        $substconfigpw = $rootpw
+      }
+    }
+  }
+  if $monitor {
+    if $monitordn {
+      $substmonitordn = $monitordn
+    } else {
+      $substmonitordn = $rootdn
+      $monitordn_is_same_as_rootdn = true
+    }
+    if $monitordn_is_same_as_rootdn {
+      $substmonitorpw = undef
+    } else {
+      if $monitorpw {
+        $substmonitorpw = $monitorpw
+      } else {
+        $substmonitorpw = $rootpw
+      }
+    }
+  }
+
   validate_bool($ssl)
   if $ssl == true {
     validate_absolute_path($ssl_cacert)

--- a/templates/slapd.conf.erb
+++ b/templates/slapd.conf.erb
@@ -35,13 +35,15 @@ TLSCertificateKeyFile  <%= @ssl_key %>
 # Define a config database (cn=config)
 
 database config
-suffix "cn=config"
-rootdn    "<%= @configdn %>"
-rootpw    "<%= @configpw %>"
+# suffix "cn=config"
+rootdn    "<%= @substconfigdn %>"
+<% if @substconfigpw -%>
+rootpw    "<%= @substconfigpw %>"
+<% end -%>
 
 access to *
         by dn.exact="gidNumber=0+uidNumber=0,cn=peercred,cn=external,cn=auth" manage
-        by dn.exact="<%= @configdn %>" manage
+        by dn.exact="<%= @substconfigdn %>" manage
         by * none
 <% end -%>
 <% if @monitor == true -%>
@@ -51,11 +53,14 @@ access to *
 
 database monitor
 # suffix "cn=Monitor"
-rootdn    "<%= @monitordn %>"
-rootpw    "<%= @monitorpw %>"
+rootdn    "<%= @substmonitordn %>"
+<% if @substmonitorpw -%>
+rootpw    "<%= @substmonitorpw %>"
+<% end -%>
+
 access to *
   by dn.exact=gidNumber=0+uidNumber=0,cn=peercred,cn=external,cn=auth" read
-  by dn.exact="<%= @monitordn %>" read
+  by dn.exact="<%= @substmonitordn %>" read
   by * none
 <% end -%>
 


### PR DESCRIPTION
the slapd.conf file.

Using a parameter, as default for another paramter as it is done in the 
server.pp file for above 4 named parameters, is not going to work as intended.
This will basically end up with 4 empty strings that get used in the template file.

Also, be more cautious, when, especially the *pw variables get
written to the file. Further, the suffix= line in the database config
section is not allowed:

Basically fixing error messages like this with enabled config and monitoring
databases:

543e1cc9 /etc/openldap/slapd.conf: line 23: suffix <cn=config> not allowed in config database.
543e1cc9 /etc/openldap/slapd.conf: line 23: <suffix> handler exited with 1!

with rootpw under database config
543e1d10 line 25 (rootpw ***)
543e1d10 /etc/openldap/slapd.conf: line 25: <rootpw> can only be set when rootdn is under suffix

with rootpw under database monitor
543e1dc6 line 38 (rootpw ***)
543e1dc6 /etc/openldap/slapd.conf: line 38: <rootpw> can only be set when rootdn is under suffix

For that last reason, the suffix= line in the config database
is commented out, as it is done for the monitor database already.

Unfortunately the setting of the parameters seems a bit confusing, but since puppet doesn't allow
re-assigning of variables, I had to work around it. 

my tests are done with openldap-2.4.40, and without explicitly setting a configdn or monitordn, because I want to have the same as the rootdn. But at least my changes make this now work for me having a config and monitoring database backend.

