### PR TITLE
Add support for CentOS 7 by providing a "/etc/sysconfig/slapd" file

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -106,8 +106,16 @@ class ldap::params {
       $server_package_name     = 'openldap-servers'
       $server_service_name     = 'slapd'
       $server_config_file      = "${ldap_config_directory}/slapd.conf"
-      $server_default_file     = "${os_config_directory}/ldap"
-      $server_default_template = 'ldap/redhat/sysconfig.erb'
+      case $::operatingsystemmajrelease {
+        '7'    : {
+          $server_default_file     = "${os_config_directory}/slapd"
+          $server_default_template = 'ldap/redhat/sysconfig-el7.erb'
+        }
+        default: {
+          $server_default_file     = "${os_config_directory}/ldap"
+          $server_default_template = 'ldap/redhat/sysconfig.erb'
+        }
+      }
       $server_directory        = '/var/lib/ldap'
       $gem_name                = 'net-ldap'
     }

--- a/spec/unit/classes/ldap_server_spec.rb
+++ b/spec/unit/classes/ldap_server_spec.rb
@@ -48,7 +48,7 @@ describe 'ldap::server', :type => :class do
     let :facts do
       {
         :osfamily               => 'RedHat',
-        :operatingsystemrelease => '6',
+        :operatingsystemrelease => '6.5',
       }
     end
 
@@ -76,6 +76,41 @@ describe 'ldap::server', :type => :class do
       :group   => '0',
       :mode    => '0644'
     )}
+  end
+  
+  context "on a RedHat 7 OS" do
+    let :facts do
+      {
+        :osfamily                  => 'RedHat',
+        :operatingsystemrelease    => '7.0.1406',
+        :operatingsystemmajrelease => '7',
+      }
+    end
+
+    it { should compile.with_all_deps }
+
+    it { should contain_package('ldap-server').with(
+      :ensure => 'present',
+      :name   => 'openldap-servers'
+    )}
+
+    it { should contain_service('ldap-server').with(
+      :ensure => 'running',
+      :enable => true,
+      :name   => 'slapd'
+    )}
+
+    it { should contain_file('/etc/openldap/slapd.conf').with(
+      :owner   => '0',
+      :group   => '0',
+      :mode    => '0644'
+    )}
+
+    it { should contain_file('/etc/sysconfig/slapd').with(
+      :owner   => '0',
+      :group   => '0',
+      :mode    => '0644'
+    ).with_content(/SLAPD_OPTIONS="-f \/etc\/openldap\/slapd.conf"/)}
   end
 
   context "on a OpenBSD OS" do

--- a/templates/redhat/sysconfig-el7.erb
+++ b/templates/redhat/sysconfig-el7.erb
@@ -1,0 +1,16 @@
+# OpenLDAP server configuration
+# see 'man slapd' for additional information
+
+# Where the server will run (-h option)
+# - ldapi:/// is required for on-the-fly configuration using client tools
+#   (use SASL with EXTERNAL mechanism for authentication)
+# - default: ldapi:/// ldap:///
+# - example: ldapi:/// ldap://127.0.0.1/ ldap://10.0.0.1:1389/ ldaps:///
+SLAPD_URLS="ldapi:/// ldap:/// <% if @ssl -%>ldaps:///<% end -%>"
+
+# Any custom options
+SLAPD_OPTIONS="-f <%= @config_file %>"
+
+# Keytab location for GSSAPI Kerberos authentication
+#KRB5_KTNAME="FILE:/etc/openldap/ldap.keytab"
+


### PR DESCRIPTION
Add support for CentOS 7 by providing a "/etc/sysconfig/slapd" file which converts OpenLDAP back to using slapd.conf.
Added additional test for RHEL 7.