### PR TITLE
Functional enhancements and cleanups

### DIFF
--- a/files/schema/groupofentries.schema
+++ b/files/schema/groupofentries.schema
@@ -1,0 +1,9 @@
+# Schema definition as per
+# http://www.ietf.org/mail-archive/web/ldapext/current/msg01141.html
+
+# allows empty groups because member is not a MUST
+objectclass ( 1.2.826.0.1.3458854.2.1.1.1 NAME 'groupOfEntries'
+    SUP top STRUCTURAL
+    MUST ( cn )
+    MAY ( member $ businessCategory $ seeAlso $ owner $ ou $ o $
+          description ) )

--- a/files/schema/rfc2307bis.schema
+++ b/files/schema/rfc2307bis.schema
@@ -1,0 +1,266 @@
+# Schema definition as per http://www.padl.com/~lukeh/rfc2307bis.txt
+
+# Attribute Type Definitions
+
+#attributetype ( 1.3.6.1.1.1.1.0 NAME 'uidNumber'
+#    DESC 'An integer uniquely identifying a user in an administrative domain'
+#    EQUALITY integerMatch
+#    SYNTAX 1.3.6.1.4.1.1466.115.121.1.27
+#    SINGLE-VALUE )
+
+#attributetype ( 1.3.6.1.1.1.1.1 NAME 'gidNumber'
+#    DESC 'An integer uniquely identifying a group in an administrative domain'
+#    EQUALITY integerMatch
+#    SYNTAX 1.3.6.1.4.1.1466.115.121.1.27
+#    SINGLE-VALUE )
+
+attributetype ( 1.3.6.1.1.1.1.2 NAME 'gecos'
+    DESC 'The GECOS field; the common name'
+    EQUALITY caseIgnoreIA5Match
+    SUBSTR caseIgnoreIA5SubstringsMatch
+    SYNTAX 1.3.6.1.4.1.1466.115.121.1.26
+    SINGLE-VALUE )
+
+attributetype ( 1.3.6.1.1.1.1.3 NAME 'homeDirectory'
+    DESC 'The absolute path to the home directory'
+    EQUALITY caseExactIA5Match
+    SYNTAX 1.3.6.1.4.1.1466.115.121.1.26
+    SINGLE-VALUE )
+
+attributetype ( 1.3.6.1.1.1.1.4 NAME 'loginShell'
+    DESC 'The path to the login shell'
+    EQUALITY caseExactIA5Match
+    SYNTAX 1.3.6.1.4.1.1466.115.121.1.26
+    SINGLE-VALUE )
+
+attributetype ( 1.3.6.1.1.1.1.5 NAME 'shadowLastChange'
+    EQUALITY integerMatch
+    SYNTAX 1.3.6.1.4.1.1466.115.121.1.27
+    SINGLE-VALUE )
+
+attributetype ( 1.3.6.1.1.1.1.6 NAME 'shadowMin'
+    EQUALITY integerMatch
+    SYNTAX 1.3.6.1.4.1.1466.115.121.1.27
+    SINGLE-VALUE )
+
+attributetype ( 1.3.6.1.1.1.1.7 NAME 'shadowMax'
+    EQUALITY integerMatch
+    SYNTAX 1.3.6.1.4.1.1466.115.121.1.27
+    SINGLE-VALUE )
+
+attributetype ( 1.3.6.1.1.1.1.8 NAME 'shadowWarning'
+    EQUALITY integerMatch
+    SYNTAX 1.3.6.1.4.1.1466.115.121.1.27
+    SINGLE-VALUE )
+
+attributetype ( 1.3.6.1.1.1.1.9 NAME 'shadowInactive'
+    EQUALITY integerMatch
+    SYNTAX 1.3.6.1.4.1.1466.115.121.1.27
+    SINGLE-VALUE )
+
+attributetype ( 1.3.6.1.1.1.1.10 NAME 'shadowExpire'
+    EQUALITY integerMatch
+    SYNTAX 1.3.6.1.4.1.1466.115.121.1.27
+    SINGLE-VALUE )
+
+attributetype ( 1.3.6.1.1.1.1.11 NAME 'shadowFlag'
+    EQUALITY integerMatch
+    SYNTAX 1.3.6.1.4.1.1466.115.121.1.27
+    SINGLE-VALUE )
+
+attributetype ( 1.3.6.1.1.1.1.12 NAME 'memberUid'
+    EQUALITY caseExactIA5Match
+    SYNTAX 1.3.6.1.4.1.1466.115.121.1.26 )
+
+attributetype ( 1.3.6.1.1.1.1.13 NAME 'memberNisNetgroup'
+    EQUALITY caseExactIA5Match
+    SUBSTR caseExactIA5SubstringsMatch
+    SYNTAX 1.3.6.1.4.1.1466.115.121.1.26 )
+
+attributetype ( 1.3.6.1.1.1.1.14 NAME 'nisNetgroupTriple'
+    DESC 'Netgroup triple'
+    EQUALITY caseIgnoreIA5Match
+    SYNTAX 1.3.6.1.4.1.1466.115.121.1.26 )
+
+attributetype ( 1.3.6.1.1.1.1.15 NAME 'ipServicePort'
+    DESC 'Service port number'
+    EQUALITY integerMatch
+    SYNTAX 1.3.6.1.4.1.1466.115.121.1.27
+    SINGLE-VALUE )
+
+attributetype ( 1.3.6.1.1.1.1.16 NAME 'ipServiceProtocol'
+    DESC 'Service protocol name'
+    SUP name )
+
+attributetype ( 1.3.6.1.1.1.1.17 NAME 'ipProtocolNumber'
+    DESC 'IP protocol number'
+    EQUALITY integerMatch
+    SYNTAX 1.3.6.1.4.1.1466.115.121.1.27
+    SINGLE-VALUE )
+
+attributetype ( 1.3.6.1.1.1.1.18 NAME 'oncRpcNumber'
+    DESC 'ONC RPC number'
+    EQUALITY integerMatch
+    SYNTAX 1.3.6.1.4.1.1466.115.121.1.27
+    SINGLE-VALUE )
+
+attributetype ( 1.3.6.1.1.1.1.19 NAME 'ipHostNumber'
+    DESC 'IPv4 addresses as a dotted decimal omitting leading zeros or IPv6 addresses as defined in RFC2373'
+    SUP name )
+
+attributetype ( 1.3.6.1.1.1.1.20 NAME 'ipNetworkNumber'
+    DESC 'IP network as a dotted decimal, eg. 192.168, omitting leading zeros'
+    SUP name
+    SINGLE-VALUE )
+
+attributetype ( 1.3.6.1.1.1.1.21 NAME 'ipNetmaskNumber'
+    DESC 'IP netmask as a dotted decimal, eg. 255.255.255.0, omitting leading zeros'
+    EQUALITY caseIgnoreIA5Match
+    SYNTAX 1.3.6.1.4.1.1466.115.121.1.26
+    SINGLE-VALUE )
+
+attributetype ( 1.3.6.1.1.1.1.22 NAME 'macAddress'
+    DESC 'MAC address in maximal, colon separated hex notation, eg. 00:00:92:90:ee:e2'
+    EQUALITY caseIgnoreIA5Match
+    SYNTAX 1.3.6.1.4.1.1466.115.121.1.26 )
+
+attributetype ( 1.3.6.1.1.1.1.23 NAME 'bootParameter'
+    DESC 'rpc.bootparamd parameter'
+    EQUALITY caseExactIA5Match
+    SYNTAX 1.3.6.1.4.1.1466.115.121.1.26 )
+
+attributetype ( 1.3.6.1.1.1.1.24 NAME 'bootFile'
+    DESC 'Boot image name'
+    EQUALITY caseExactIA5Match
+    SYNTAX 1.3.6.1.4.1.1466.115.121.1.26 )
+
+attributetype ( 1.3.6.1.1.1.1.26 NAME 'nisMapName'
+    DESC 'Name of a A generic NIS map'
+    SUP name )
+
+attributetype ( 1.3.6.1.1.1.1.27 NAME 'nisMapEntry'
+    DESC 'A generic NIS entry'
+    EQUALITY caseExactIA5Match
+    SUBSTR caseExactIA5SubstringsMatch
+    SYNTAX 1.3.6.1.4.1.1466.115.121.1.26
+    SINGLE-VALUE )
+
+attributetype ( 1.3.6.1.1.1.1.28 NAME 'nisPublicKey'
+    DESC 'NIS public key'
+    EQUALITY octetStringMatch
+    SYNTAX 1.3.6.1.4.1.1466.115.121.1.40 SINGLE-VALUE )
+
+attributetype ( 1.3.6.1.1.1.1.29 NAME 'nisSecretKey'
+    DESC 'NIS secret key'
+    EQUALITY octetStringMatch
+    SYNTAX 1.3.6.1.4.1.1466.115.121.1.40 SINGLE-VALUE )
+
+attributetype ( 1.3.6.1.1.1.1.30 NAME 'nisDomain'
+    DESC 'NIS domain'
+    EQUALITY caseIgnoreIA5Match
+    SYNTAX 1.3.6.1.4.1.1466.115.121.1.26)
+
+attributetype ( 1.3.6.1.1.1.1.31 NAME 'automountMapName'
+    DESC 'automount Map Name'
+    EQUALITY caseExactIA5Match
+    SUBSTR caseExactIA5SubstringsMatch
+    SYNTAX 1.3.6.1.4.1.1466.115.121.1.26 SINGLE-VALUE )
+
+attributetype ( 1.3.6.1.1.1.1.32 NAME 'automountKey'
+    DESC 'Automount Key value'
+    EQUALITY caseExactIA5Match
+    SUBSTR caseExactIA5SubstringsMatch
+    SYNTAX 1.3.6.1.4.1.1466.115.121.1.26 SINGLE-VALUE )
+
+attributetype ( 1.3.6.1.1.1.1.33 NAME 'automountInformation'
+    DESC 'Automount information'
+    EQUALITY caseExactIA5Match
+    SUBSTR caseExactIA5SubstringsMatch
+    SYNTAX 1.3.6.1.4.1.1466.115.121.1.26 SINGLE-VALUE )
+
+# Object Class Definitions
+
+objectclass ( 1.3.6.1.1.1.2.0 NAME 'posixAccount' SUP top AUXILIARY
+    DESC 'Abstraction of an account with POSIX attributes'
+    MUST ( cn $ uid $ uidNumber $ gidNumber $ homeDirectory )
+    MAY ( userPassword $ loginShell $ gecos $ description ) )
+
+objectclass ( 1.3.6.1.1.1.2.1 NAME 'shadowAccount' SUP top AUXILIARY
+    DESC 'Additional attributes for shadow passwords'
+    MUST uid
+    MAY ( userPassword $ description $ shadowLastChange $ shadowMin $
+          shadowMax $ shadowWarning $ shadowInactive $ shadowExpire $
+          shadowFlag ) )
+
+objectclass ( 1.3.6.1.1.1.2.2 NAME 'posixGroup' SUP top AUXILIARY
+    DESC 'Abstraction of a group of accounts'
+    MUST gidNumber
+    MAY ( userPassword $ memberUid $ description ) )
+
+objectclass ( 1.3.6.1.1.1.2.3 NAME 'ipService' SUP top STRUCTURAL
+    DESC 'Abstraction an Internet Protocol service'
+    MUST ( cn $ ipServicePort $ ipServiceProtocol )
+    MAY description )
+
+objectclass ( 1.3.6.1.1.1.2.4 NAME 'ipProtocol' SUP top STRUCTURAL
+    DESC 'Abstraction of an IP protocol'
+    MUST ( cn $ ipProtocolNumber )
+    MAY description )
+
+objectclass ( 1.3.6.1.1.1.2.5 NAME 'oncRpc' SUP top STRUCTURAL
+    DESC 'Abstraction of an Open Network Computing (ONC) [RFC1057]'
+    MUST ( cn $ oncRpcNumber )
+    MAY description )
+
+objectclass ( 1.3.6.1.1.1.2.6 NAME 'ipHost' SUP top AUXILIARY
+    DESC 'Abstraction of a host, an IP device'
+    MUST ( cn $ ipHostNumber )
+    MAY ( userPassword $ l $ description $ manager ) )
+
+objectclass ( 1.3.6.1.1.1.2.7 NAME 'ipNetwork' SUP top STRUCTURAL
+    DESC 'Abstraction of a network'
+    MUST ipNetworkNumber
+    MAY ( cn $ ipNetmaskNumber $ l $ description $ manager ) )
+
+objectclass ( 1.3.6.1.1.1.2.8 NAME 'nisNetgroup' SUP top STRUCTURAL
+    DESC 'Abstraction of a netgroup. May refer to other netgroups'
+    MUST cn
+    MAY ( nisNetgroupTriple $ memberNisNetgroup $ description ) )
+
+objectclass ( 1.3.6.1.1.1.2.9 NAME 'nisMap' SUP top STRUCTURAL
+    DESC 'A generic abstraction of a NIS map'
+    MUST nisMapName
+    MAY description )
+
+objectclass ( 1.3.6.1.1.1.2.10 NAME 'nisObject' SUP top STRUCTURAL
+    DESC 'An entry in a NIS map'
+    MUST ( cn $ nisMapEntry $ nisMapName )
+    MAY description )
+
+objectclass ( 1.3.6.1.1.1.2.11 NAME 'ieee802Device' SUP top AUXILIARY
+    DESC 'A device with a MAC address; device SHOULD be
+    used as a structural class'
+    MAY macAddress )
+
+objectclass ( 1.3.6.1.1.1.2.12 NAME 'bootableDevice' SUP top AUXILIARY
+    DESC 'A device with boot parameters; device SHOULD be
+    used as a structural class'
+    MAY ( bootFile $ bootParameter ) )
+
+objectclass ( 1.3.6.1.1.1.2.14 NAME 'nisKeyObject' SUP top AUXILIARY
+    DESC 'An object with a public and secret key'
+    MUST ( cn $ nisPublicKey $ nisSecretKey )
+    MAY ( uidNumber $ description ) )
+
+objectclass ( 1.3.6.1.1.1.2.15 NAME 'nisDomainObject' SUP top AUXILIARY
+    DESC 'Associates a NIS domain with a naming context'
+    MUST nisDomain )
+
+objectclass ( 1.3.6.1.1.1.2.16 NAME 'automountMap' SUP top STRUCTURAL
+    MUST ( automountMapName )
+    MAY description )
+
+objectclass ( 1.3.6.1.1.1.2.17 NAME 'automount' SUP top STRUCTURAL
+    DESC 'Automount information'
+    MUST ( automountKey $ automountInformation )
+    MAY description )

--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -28,6 +28,12 @@
 # [*ssl_reqcert*]
 #   How CA validation is being handled (never, allow, try, demand).
 #
+# [*sizelimit*]
+#   Maximum number of entries to return by default.
+#
+# [*timelimit*]
+#   Maximum number of seconds to wait for answers by default.
+#
 # === Examples
 #
 #  class { 'ldap::client':
@@ -51,6 +57,8 @@ class ldap::client (
   $config_template  = $ldap::params::client_config_template,
   $gem_name         = $ldap::params::gem_name,
   $gem_ensure       = $ldap::params::gem_ensure,
+  $sizelimit        = $ldap::params::client_sizelimit,
+  $timelimit        = $ldap::params::client_timelimit,
 ) inherits ldap::params {
 
   include stdlib
@@ -63,9 +71,15 @@ class ldap::client (
       validate_absolute_path($ssl_cacertdir)
     }
     validate_absolute_path($ssl_cacert)
-    validate_absolute_path($ssl_cert)
-    validate_absolute_path($ssl_key)
-    validate_re($ssl_reqcert, ['never', 'allow', 'try', 'demand'])
+    if $ssl_cert {
+      validate_absolute_path($ssl_cert)
+    }
+    if $ssl_key {
+      validate_absolute_path($ssl_key)
+    }
+    if $ssl_reqcert {
+      validate_re($ssl_reqcert, ['never', 'allow', 'try', 'demand'])
+    }
   }
 
   anchor { 'ldap::client::begin': } ->

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -14,11 +14,15 @@ class ldap::params {
   $client_ssl_key         = undef
   $client_ssl_reqcert     = 'demand'
 
+  $client_sizelimit = undef
+  $client_timelimit = 15
+
   $server_package_ensure      = 'present'
   $server_service_enable      = true
   $server_service_ensure      = 'running'
   $server_service_manage      = true
   $server_config_template     = 'ldap/slapd.conf.erb'
+  $server_backend             = 'bdb'
   $server_db_config_file      = "${server_directory}/DB_CONFIG"
   $server_db_config_template  = 'ldap/DB_CONFIG.erb'
 
@@ -28,9 +32,22 @@ class ldap::params {
   $server_ssl_cacert = undef
   $server_ssl_cert   = undef
   $server_ssl_key    = undef
+  $server_ssl_verify_client = undef
 
   $config           = false
   $monitor          = false
+
+  $server_access = [
+    # to what
+    { 'attrs=userPassword,shadowLastChange' => [
+      # by who => access
+      { 'self' => '@@writeable_on_sync_provider_only@@' },
+      { 'anonymous' => 'auth' },
+    ] },
+    { 'attrs=objectClass,cn,uid,uidNumber,gidNumber,gecos,homeDirectory,loginShell,member,memberUid,entry' => [
+      { '*' => 'read' },
+    ] },
+  ]
 
   $server_bind_anon = false
   $server_bind_v2   = true
@@ -38,6 +55,7 @@ class ldap::params {
   $server_overlays  = [ ]
   $server_modules   = [ ]
   $server_schemas   = [ 'core', 'cosine', 'nis', 'inetorgperson' ]
+  $server_extra_schemas = [ ]
   $server_indexes   = [ 'objectclass  eq',
                         'entryCSN     eq',
                         'entryUUID    eq',
@@ -48,24 +66,33 @@ class ldap::params {
                         'uid          pres,sub,eq',
                         'displayName  pres,sub,eq' ]
 
+  $server_sync_rid            = undef
+  $server_sync_provider       = undef
+  $server_sync_type           = undef
+  $server_sync_interval       = undef
+  $server_sync_filter         = undef
+  $server_sync_scope          = undef
+  $server_sync_attrs          = undef
+  $server_sync_schemachecking = undef
+  $server_sync_bindmethod     = undef
+  $server_sync_binddn         = undef
+  $server_sync_credentials    = undef
+
   $gem_ensure       = 'present'
 
   case $::osfamily {
     'Debian': {
       $ldap_config_directory   = '/etc/ldap'
       $os_config_directory     = '/etc/default'
+      $server_run_directory    = '/var/run/slapd'
 
       $client_package_name     = 'libldap-2.4-2'
-      $client_config_file      = "${ldap_config_directory}/ldap.conf"
 
-      $pidfile                 = '/var/run/slapd/slapd.pid'
-      $argsfile                = '/var/run/slapd/slapd.args'
-      $ldapowner               = '0'
-      $ldapgroup               = '0'
+      $ldapowner               = 'openldap'
+      $ldapgroup               = 'openldap'
 
       $server_package_name     = 'slapd'
       $server_service_name     = 'slapd'
-      $server_config_file      = "${ldap_config_directory}/slapd.conf"
       $server_default_file     = "${os_config_directory}/slapd"
       $server_default_template = 'ldap/debian/defaults.erb'
       $server_directory        = '/var/lib/ldap'
@@ -74,18 +101,15 @@ class ldap::params {
     'OpenBSD': {
       $ldap_config_directory   = '/etc/openldap'
       $os_config_directory     = undef
+      $server_run_directory    = '/var/run/openldap'
 
       $client_package_name     = 'openldap-client'
-      $client_config_file      = "${ldap_config_directory}/ldap.conf"
 
-      $pidfile                 = '/var/run/openldap/slapd.pid'
-      $argsfile                = '/var/run/openldap/slapd.args'
       $ldapowner               = '_openldap'
       $ldapgroup               = '_openldap'
 
       $server_package_name     = 'openldap-server'
       $server_service_name     = 'slapd'
-      $server_config_file      = "${ldap_config_directory}/slapd.conf"
       $server_default_file     = undef
       $server_default_template = undef
       $server_directory        = '/var/openldap-data'
@@ -94,18 +118,15 @@ class ldap::params {
     'RedHat': {
       $ldap_config_directory   = '/etc/openldap'
       $os_config_directory     = '/etc/sysconfig'
+      $server_run_directory    = '/var/run/openldap'
 
       $client_package_name     = 'openldap-clients'
-      $client_config_file      = "${ldap_config_directory}/ldap.conf"
-      $ldapowner               = '0'
-      $ldapgroup               = '0'
 
-      $pidfile                 = '/var/run/openldap/slapd.pid'
-      $argsfile                = '/var/run/openldap/slapd.args'
+      $ldapowner               = 'ldap'
+      $ldapgroup               = 'ldap'
 
       $server_package_name     = 'openldap-servers'
       $server_service_name     = 'slapd'
-      $server_config_file      = "${ldap_config_directory}/slapd.conf"
       $server_default_file     = "${os_config_directory}/ldap"
       $server_default_template = 'ldap/redhat/sysconfig.erb'
       $server_directory        = '/var/lib/ldap'
@@ -115,4 +136,17 @@ class ldap::params {
       fail("${::module_name} is not supported on ${::osfamily}.")
     }
   }
+
+  $client_config_file         = "${ldap_config_directory}/ldap.conf"
+  $server_config_file         = "${ldap_config_directory}/slapd.conf"
+  $server_dynconfig_directory = "${ldap_config_directory}/slapd.d"
+  $server_schema_directory    = "${ldap_config_directory}/schema"
+  $pidfile                    = "${server_run_directory}/slapd.pid"
+  $argsfile                   = "${server_run_directory}/slapd.args"
+
+  $server_purge_dynconfig_dir = false
+
+  $server_kerberos            = false
+  $server_krb5_keytab         = "${ldap_config_directory}/ldap.keytab"
+  $server_krb5_ticket_cache   = "${ldap_config_directory}/ldap.krb5cc"
 }

--- a/manifests/schema_file.pp
+++ b/manifests/schema_file.pp
@@ -1,0 +1,12 @@
+# == Type ldap::schema_file
+#
+# Import extra schema files from the master
+#
+define ldap::schema_file ($schema = $title, $directory) {
+  file { "${directory}/$schema.schema":
+    owner   => 0,
+    group   => 0,
+    mode    => '0644',
+    source  => "puppet:///modules/ldap/schema/$schema.schema",
+  }
+}

--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -6,7 +6,8 @@ class ldap::server::config inherits ldap::server {
   file { $ldap::server::config_file:
     owner   => $ldap::server::ldapowner,
     group   => $ldap::server::ldapgroup,
-    mode    => '0644',
+    # may contain passwords
+    mode    => '0400',
     content => template($ldap::server::config_template),
   }
 
@@ -19,10 +20,41 @@ class ldap::server::config inherits ldap::server {
     }
   }
 
-  file { $ldap::server::db_config_file:
+  file { $ldap::server::schema_directory:
+    ensure => directory,
+    owner => 0,
+    group => 0,
+    mode => 755,
+  }
+  ->
+  ldap::schema_file { $ldap::server::extra_schemas:
+    directory => $ldap::server::schema_directory,
+  }
+
+  file { $ldap::server::directory:
+    ensure => "directory",
     owner   => $ldap::server::ldapowner,
     group   => $ldap::server::ldapgroup,
-    mode    => '0644',
-    content => template($ldap::server::db_config_template),
+    mode    => '0700',
   }
+
+  if $ldap::server::backend == 'bdb' or $ldap::server::backend == 'hdb' {
+    file { $ldap::server::db_config_file:
+      owner   => $ldap::server::ldapowner,
+      group   => $ldap::server::ldapgroup,
+      mode    => '0644',
+      content => template($ldap::server::db_config_template),
+      require => File[$ldap::server::directory],
+    }
+  }
+
+  if $ldap::server::dynconfig_directory and $ldap::server::purge_dynconfig_dir == true {
+    file { $ldap::server::dynconfig_directory:
+      path => $ldap::server::dynconfig_directory,
+      ensure => absent,
+      recurse => true,
+      purge => true,
+      force => true,
+     }
+   }
 }

--- a/templates/debian/defaults.erb
+++ b/templates/debian/defaults.erb
@@ -5,11 +5,11 @@ SLAPD_CONF=/etc/ldap/slapd.conf
 
 # System account to run the slapd server under. If empty the server
 # will run as root.
-SLAPD_USER="<%= @server_user %>"
+SLAPD_USER="<%= @ldapowner %>"
 
 # System group to run the slapd server under. If empty the server will
 # run in the primary group of its user.
-SLAPD_GROUP="<%= @server_group %>"
+SLAPD_GROUP="<%= @ldapgroup %>"
 
 # Path to the pid file of the slapd server. If not set the init.d script
 # will try to figure it out from $SLAPD_CONF (/etc/ldap/slapd.conf by
@@ -33,6 +33,19 @@ SLAPD_SERVICES="ldap:/// ldapi:///"
 # maintenance, for example, or through a configuration management system)
 # when you don't want to edit a configuration file.
 SLAPD_SENTINEL_FILE=/etc/ldap/noslapd
+
+# For Kerberos authentication (via SASL), slapd by default uses the system
+# keytab file (/etc/krb5.keytab).  To use a different keytab file,
+# uncomment this line and change the path.
+#export KRB5_KTNAME=/etc/krb5.keytab
+<% if @kerberos -%>
+<%   if @krb5_keytab -%>
+export KRB5_KTNAME=<%= @krb5_keytab %>
+<%   end -%>
+<%   if @krb5_ticket_cache -%>
+export KRB5CCNAME=<%= @krb5_ticket_cache %>
+<%   end -%>
+<% end -%>
 
 # Additional options to pass to slapd
 SLAPD_OPTIONS=""

--- a/templates/ldap.conf.erb
+++ b/templates/ldap.conf.erb
@@ -3,14 +3,26 @@ BASE <%= @base %>
 URI  <%= @uri %>
 
 # Timeout options
-SIZELIMIT 12
-TIMELIMIT 15
+<%- if @sizelimit -%>
+SIZELIMIT <%= @sizelimit %>
+<% end -%>
+<%- if @timelimit -%>
+TIMELIMIT <%= @timelimit %>
+<% end -%>
 
 <%- if @ssl == true -%>
 # SSL
-<% if @ssl_cacertdir %>TLS_CACERTDIR <%= @ssl_cacertdir %><%- end %>
+<% if @ssl_cacertdir -%>
+TLS_CACERTDIR <%= @ssl_cacertdir %>
+<% end -%>
 TLS_CACERT <%= @ssl_cacert %>
+<% if @ssl_cert -%>
 TLS_CERT <%= @ssl_cert %>
+<% end -%>
+<% if @ssl_key -%>
 TLS_KEY <%= @ssl_key %>
+<% end -%>
+<% if @ssl_reqcert -%>
 TLS_REQCERT <%= @ssl_reqcert %>
+<% end -%>
 <% end -%>

--- a/templates/slapd.conf.erb
+++ b/templates/slapd.conf.erb
@@ -14,12 +14,12 @@ allow bind_v2
 <% end -%>
 
 # Schemas
-<% @schemas.each do |s| -%>
-include <%= @config_directory %>/schema/<%= s %>.schema
+<% @schemas.concat(@extra_schemas).each do |s| -%>
+include <%= @schema_directory %>/<%= s %>.schema
 <% end -%>
 
 # Modules
-moduleload back_bdb
+moduleload back_<%= @backend %>
 <% @modules.each do |m| -%>
 moduleload <%= m %>
 <% end -%>
@@ -29,7 +29,35 @@ moduleload <%= m %>
 TLSCACertificateFile   <%= @ssl_cacert %>
 TLSCertificateFile     <%= @ssl_cert %>
 TLSCertificateKeyFile  <%= @ssl_key %>
+<%   if @ssl_verify_client -%>
+TLSVerifyClient        <%= @ssl_verify_client %>
+<%   end -%>
 <% end -%>
+
+# Access control ...
+access to dn.exact=""
+  by dn.exact="gidNumber=0+uidNumber=0,cn=peercred,cn=external,cn=auth" <%= @access_for_ldapi_rootdn_cfg %>
+  by * read
+access to dn.exact="cn=Subschema"
+  by * read
+
+<% @access.each do |torule| -%>
+<%   torule.each do |what,byrules| -%>
+access to <%= what %>
+  by dn.exact="gidNumber=0+uidNumber=0,cn=peercred,cn=external,cn=auth" <%= @access_for_ldapi_rootdn_cfg %>
+<%     byrules.each do |byrule| -%>
+<%       byrule.each do |who, access| -%>
+<%         access.sub!('@@writeable_on_sync_provider_only@@', @access_writeable_on_sync_provider_only_cfg) -%>
+  by <%= who %> <%= access %>
+<%       end -%>
+<%     end -%>
+<%   end -%>
+  by * none
+<% end -%>
+
+access to *
+  by dn.exact="gidNumber=0+uidNumber=0,cn=peercred,cn=external,cn=auth" <%= @access_for_ldapi_rootdn_cfg %>
+  by * none
 
 <% if @config == true -%>
 # Define a config database (cn=config)
@@ -43,6 +71,7 @@ access to *
         by dn.exact="gidNumber=0+uidNumber=0,cn=peercred,cn=external,cn=auth" manage
         by dn.exact="<%= @configdn %>" manage
         by * none
+
 <% end -%>
 <% if @monitor == true -%>
 # Define a monitoring database (http://www.openldap.org/doc/admin24/backends.html#Monitor)
@@ -60,7 +89,7 @@ access to *
 <% end -%>
 
 # Database definition
-database  bdb
+database  <%= @backend %>
 directory <%= @directory %>
 suffix    "<%= @suffix %>"
 rootdn    "<%= @rootdn %>"
@@ -70,12 +99,49 @@ rootpw    "<%= @rootpw %>"
 <% @overlays.each do |o| -%>
 overlay <%= o %>
 <% end -%>
+<% if @sync_provider -%>
+
+# Replication
+syncrepl
+  rid=<%= @sync_rid %>
+  provider=<%= @sync_provider %>
+  searchbase=<%= @sync_searchbase_cfg %>
+<% if @sync_type -%>
+  type=<%= @sync_type %>
+<% end -%>
+<% if @sync_interval -%>
+  interval=<%= @sync_interval %>
+<% end -%>
+<% if @sync_filter -%>
+  filter=<%= @sync_filter %>
+<% end -%>
+<% if @sync_scope -%>
+  scope=<%= @sync_scope %>
+<% end -%>
+<% if @sync_attrs -%>
+  attrs=<%= @sync_attrs.join(',') %>
+<% end -%>
+<% if @sync_schemachecking -%>
+  schemachecking=<%= @sync_schemachecking %>
+<% end -%>
+<% if @sync_bindmethod -%>
+  bindmethod=<%= @sync_bindmethod %>
+<% end -%>
+<% if not @bind_method or @sync_bindmethod == "simple" -%>
+  binddn=<%= @sync_binddn %>
+  credentials=<%= @sync_credentials %>
+<% end -%>
+
+updateref <%= @sync_master_uri_cfg %>
+<% end -%>
 
 # Indexes
 <% @indexes.each do |i| -%>
 index <%= i %>
 <% end -%>
+<% if @backend == "bdb" -%>
 
 # Database parameters
 cachesize 10000
 checkpoint 128 15
+<% end -%>


### PR DESCRIPTION
Hi,

I've added a few enhancements to the module and did some what seems to me like cleanups. Would you be interested in including them?

I've dumped them all in this rather large commit. Please let me know if you'd prefer a series of smaller patches.

Thanks!
Michael

The changes:

Make timelimit and sizelimit on client configurable. Remove default
sizelimit of 12 entries. Do not require SSL cert and key on the client.

Support syncrepl replication on the server. Provide flexible way to
configure ACLs. Account for different needs on provider (master) and
consumer (slave) in access rights.

Support import of additional schema files from puppet master and provide
one for RFC2307bis and groupOfEntries proposal.

Allow configuration of SSL and Kerberos authentication at the server.

Allow use of backends other than bdb. Only include dbconfig if back_bdb
is in use - mdb does not need it. Only import DB_CONFIG if bdb or hdb
are used. Fix setting of server user in Debian defaults file. Add option
to make sure slapd.d directory is purged. Secure permissions of
slapd.conf.