### PR TITLE
Add client limit settings and make SSL auth optional

### DIFF
--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -28,6 +28,12 @@
 # [*ssl_reqcert*]
 #   How CA validation is being handled (never, allow, try, demand).
 #
+# [*sizelimit*]
+#   Maximum number of entries to return by default.
+#
+# [*timelimit*]
+#   Maximum number of seconds to wait for answers by default.
+#
 # === Examples
 #
 #  class { 'ldap::client':
@@ -51,6 +57,8 @@ class ldap::client (
   $config_template  = $ldap::params::client_config_template,
   $gem_name         = $ldap::params::gem_name,
   $gem_ensure       = $ldap::params::gem_ensure,
+  $sizelimit        = $ldap::params::client_sizelimit,
+  $timelimit        = $ldap::params::client_timelimit,
 ) inherits ldap::params {
 
   include stdlib
@@ -63,9 +71,15 @@ class ldap::client (
       validate_absolute_path($ssl_cacertdir)
     }
     validate_absolute_path($ssl_cacert)
-    validate_absolute_path($ssl_cert)
-    validate_absolute_path($ssl_key)
-    validate_re($ssl_reqcert, ['never', 'allow', 'try', 'demand'])
+    if $ssl_cert {
+      validate_absolute_path($ssl_cert)
+    }
+    if $ssl_key {
+      validate_absolute_path($ssl_key)
+    }
+    if $ssl_reqcert {
+      validate_re($ssl_reqcert, ['never', 'allow', 'try', 'demand'])
+    }
   }
 
   anchor { 'ldap::client::begin': } ->

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -14,6 +14,9 @@ class ldap::params {
   $client_ssl_key         = undef
   $client_ssl_reqcert     = 'demand'
 
+  $client_sizelimit = undef
+  $client_timelimit = 15
+
   $server_package_ensure      = 'present'
   $server_service_enable      = true
   $server_service_ensure      = 'running'

--- a/templates/ldap.conf.erb
+++ b/templates/ldap.conf.erb
@@ -3,14 +3,26 @@ BASE <%= @base %>
 URI  <%= @uri %>
 
 # Timeout options
-SIZELIMIT 12
-TIMELIMIT 15
+<%- if @sizelimit -%>
+SIZELIMIT <%= @sizelimit %>
+<% end -%>
+<%- if @timelimit -%>
+TIMELIMIT <%= @timelimit %>
+<% end -%>
 
 <%- if @ssl == true -%>
 # SSL
-<% if @ssl_cacertdir %>TLS_CACERTDIR <%= @ssl_cacertdir %><%- end %>
+<% if @ssl_cacertdir -%>
+TLS_CACERTDIR <%= @ssl_cacertdir %>
+<% end -%>
 TLS_CACERT <%= @ssl_cacert %>
+<% if @ssl_cert -%>
 TLS_CERT <%= @ssl_cert %>
+<% end -%>
+<% if @ssl_key -%>
 TLS_KEY <%= @ssl_key %>
+<% end -%>
+<% if @ssl_reqcert -%>
 TLS_REQCERT <%= @ssl_reqcert %>
+<% end -%>
 <% end -%>


### PR DESCRIPTION
Add option to configure time and size limit. Remove default of 12
entries for sizelimit. Do not forcibly require client SSL key and
certificate if SSL is enabled.