### PR TITLE
Support backends other than bdb

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -19,6 +19,7 @@ class ldap::params {
   $server_service_ensure      = 'running'
   $server_service_manage      = true
   $server_config_template     = 'ldap/slapd.conf.erb'
+  $server_backend             = 'bdb'
   $server_db_config_file      = "${server_directory}/DB_CONFIG"
   $server_db_config_template  = 'ldap/DB_CONFIG.erb'
 

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -135,7 +135,7 @@ class ldap::server (
   validate_string($rootdn)
   validate_string($rootpw)
   validate_absolute_path($directory)
-  validate_string($backend)
+  validate_re($backend, ['bdb', 'hdb', 'mdb'])
   validate_string($log_level)
   validate_array($schemas)
   validate_array($modules)

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -22,6 +22,9 @@
 # [*ldapgroup*]
 #   The group of the slapd and database configuration files.
 #
+# [*backend*]
+#   Database backend to use.
+#
 # [*log_level*]
 #   Daemon logging level, see http://www.openldap.org/doc/admin24/slapdconfig.html.
 #
@@ -93,6 +96,7 @@ class ldap::server (
   $monitordn        = $rootdn,
   $monitorpw        = $rootpw,
   $directory        = $ldap::params::server_directory,
+  $backend          = $ldap::params::server_backend,
   $log_level        = $ldap::params::server_log_level,
   $schemas          = $ldap::params::server_schemas,
   $modules          = $ldap::params::server_modules,
@@ -131,6 +135,7 @@ class ldap::server (
   validate_string($rootdn)
   validate_string($rootpw)
   validate_absolute_path($directory)
+  validate_string($backend)
   validate_string($log_level)
   validate_array($schemas)
   validate_array($modules)

--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -19,10 +19,20 @@ class ldap::server::config inherits ldap::server {
     }
   }
 
-  file { $ldap::server::db_config_file:
+  file { $ldap::server::directory:
+    ensure => "directory",
     owner   => $ldap::server::ldapowner,
     group   => $ldap::server::ldapgroup,
-    mode    => '0644',
-    content => template($ldap::server::db_config_template),
+    mode    => '0700',
+  }
+
+  if $ldap::server::backend == 'bdb' or $ldap::server::backend == 'hdb' {
+    file { $ldap::server::db_config_file:
+      owner   => $ldap::server::ldapowner,
+      group   => $ldap::server::ldapgroup,
+      mode    => '0644',
+      content => template($ldap::server::db_config_template),
+      require => File[$ldap::server::directory],
+    }
   }
 }

--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -20,10 +20,10 @@ class ldap::server::config inherits ldap::server {
   }
 
   file { $ldap::server::directory:
-    ensure => "directory",
-    owner   => $ldap::server::ldapowner,
-    group   => $ldap::server::ldapgroup,
-    mode    => '0700',
+    ensure => directory,
+    owner  => $ldap::server::ldapowner,
+    group  => $ldap::server::ldapgroup,
+    mode   => '0700',
   }
 
   if $ldap::server::backend == 'bdb' or $ldap::server::backend == 'hdb' {

--- a/templates/slapd.conf.erb
+++ b/templates/slapd.conf.erb
@@ -19,7 +19,7 @@ include <%= @config_directory %>/schema/<%= s %>.schema
 <% end -%>
 
 # Modules
-moduleload back_bdb
+moduleload back_<%= @backend %>
 <% @modules.each do |m| -%>
 moduleload <%= m %>
 <% end -%>
@@ -60,7 +60,7 @@ access to *
 <% end -%>
 
 # Database definition
-database  bdb
+database  <%= @backend %>
 directory <%= @directory %>
 suffix    "<%= @suffix %>"
 rootdn    "<%= @rootdn %>"
@@ -75,7 +75,9 @@ overlay <%= o %>
 <% @indexes.each do |i| -%>
 index <%= i %>
 <% end -%>
+<% if @backend == "bdb" -%>
 
 # Database parameters
 cachesize 10000
 checkpoint 128 15
+<% end -%>


### PR DESCRIPTION
Only create DB_CONFIG if a backend that uses it is in use. Also only add
dbconfig directives to slapd.conf if bdb ist in use because the others
don't support them.