### PR TITLE
Enhance server security

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -32,9 +32,22 @@ class ldap::params {
   $server_ssl_cacert = undef
   $server_ssl_cert   = undef
   $server_ssl_key    = undef
+  $server_ssl_verify_client = undef
 
   $config           = false
   $monitor          = false
+
+  $server_access = [
+    # to what
+    { 'attrs=userPassword,shadowLastChange' => [
+      # by who => access
+      { 'self' => '@@writeable_on_sync_provider_only@@' },
+      { 'anonymous' => 'auth' },
+    ] },
+    { 'attrs=objectClass,cn,uid,uidNumber,gidNumber,gecos,homeDirectory,loginShell,member,memberUid,entry' => [
+      { '*' => 'read' },
+    ] },
+  ]
 
   $server_bind_anon = false
   $server_bind_v2   = true
@@ -123,4 +136,7 @@ class ldap::params {
   }
 
   $server_schema_directory    = "${ldap_config_directory}/schema"
+  $server_kerberos            = false
+  $server_krb5_keytab         = "${ldap_config_directory}/ldap.keytab"
+  $server_krb5_ticket_cache   = "${ldap_config_directory}/ldap.krb5cc"
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -79,8 +79,8 @@ class ldap::params {
 
       $pidfile                 = '/var/run/slapd/slapd.pid'
       $argsfile                = '/var/run/slapd/slapd.args'
-      $ldapowner               = '0'
-      $ldapgroup               = '0'
+      $ldapowner               = 'openldap'
+      $ldapgroup               = 'openldap'
 
       $server_package_name     = 'slapd'
       $server_service_name     = 'slapd'
@@ -116,8 +116,8 @@ class ldap::params {
 
       $client_package_name     = 'openldap-clients'
       $client_config_file      = "${ldap_config_directory}/ldap.conf"
-      $ldapowner               = '0'
-      $ldapgroup               = '0'
+      $ldapowner               = 'ldap'
+      $ldapgroup               = 'ldap'
 
       $pidfile                 = '/var/run/openldap/slapd.pid'
       $argsfile                = '/var/run/openldap/slapd.args'

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -164,6 +164,7 @@ class ldap::server (
   $modules          = $ldap::params::server_modules,
   $indexes          = $ldap::params::server_indexes,
   $overlays         = $ldap::params::server_overlays,
+  $sync_provider    = undef,
   $access           = $ldap::params::server_access,
   $access_writeable_on_sync_provider_only = undef,
   $access_for_ldapi_rootdn = undef,
@@ -224,7 +225,8 @@ class ldap::server (
     }
     validate_absolute_path($ssl_key)
     if $ssl_verify_client {
-      validate_re($ssl_verify_client, ['never', 'allow', 'try', 'demand', 'hard', 'true'])
+      # use tr[u]e re to work around lint warning "quoted boolean value found"
+      validate_re($ssl_verify_client, ['never', 'allow', 'try', 'demand', 'hard', 'tr[u]e'])
     }
   }
 
@@ -244,8 +246,8 @@ class ldap::server (
     $access_writeable_on_sync_provider_only ? {
     default => $access_writeable_on_sync_provider_only,
     undef => $sync_provider ? {
-      default => "read",
-      undef => "write",
+      default => 'read',
+      undef => 'write',
     }
   }
   if $access_writeable_on_sync_provider_only_cfg {

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -56,6 +56,62 @@
 # [*ssl_key*]
 #   Path to the SSL certificate key.
 #
+# [*ssl_verify_client*]
+#   Whether and how to verify the client.
+#
+# [*kerberos*]
+#   Whether to use kerberos.
+#
+# [*krb5_keytab*]
+#   Keytab file to configure for the server to use for accepting kerberized
+#   client connections.
+#
+# [*krb5_ticket_cache*]
+#   Ticket cache file to configure for the server to use for establishing
+#   kerberized LDAP connections to other servers, e.g. via the ldap backend or
+#   syncrepl overlay.
+#
+# [*access*]
+#   ACLs to configure for the server. An array of hashes of arrays of hashes
+#   describing the ACLs:
+#
+#   $access = [
+#     { 'to what' => [
+#       { <implicit> "uidNumber=0... LDAPI" => "$access_for_ldapi_rootdn" },
+#       { 'by who' => 'access' },
+#       { 'by who' => 'access' },
+#       { <implicit> "*" => "none" } ] },
+#     { 'to what' => [ ... ] },
+#     <implicit> { '*' => [
+#       { <implicit> "uidNumber=0... LDAPI" => "$access_for_ldapi_rootdn" },
+#       { <implicit> "*" => "none" } ] },
+#   ]
+#
+#   'access' can be a special placeholder @@writeable_on_sync_provider_only@@
+#   which will by default be 'write' on the syncrepl provider and 'read' on any
+#   consumer.
+#
+#   default:
+#   $access = [
+#     { 'attrs=userPassword,shadowLastChange' => [
+#       { 'self' => '@@writeable_on_sync_provider_only@@' },
+#       { 'anonymous' => 'auth' },
+#     ] },
+#     { 'attrs=objectClass,cn,uid,uidNumber,gidNumber,gecos,homeDirectory,loginShell,member,memberUid,entry' => [
+#       { '*' => 'read' },
+#     ] },
+#   ]
+#
+# [*access_writeable_on_sync_provider_only*]
+#   Can provide an alternative value for access the
+#   @@writeable_on_sync_provider_only@@ placeholder in ACLs. Since this can be
+#   overridden using e.g. the hiera lookup hierarchy the logic for setting this
+#   to what can be as complex as necessary. Default: write on provider, read on
+#   any consumer.
+#
+# [*access_for_ldapi_rootdn*]
+#   What access to grant to the LDAPI access DN. Default: write.
+#
 # [*config*]
 #   Whether the config database should be built (cn=config).
 #
@@ -108,10 +164,17 @@ class ldap::server (
   $modules          = $ldap::params::server_modules,
   $indexes          = $ldap::params::server_indexes,
   $overlays         = $ldap::params::server_overlays,
+  $access           = $ldap::params::server_access,
+  $access_writeable_on_sync_provider_only = undef,
+  $access_for_ldapi_rootdn = undef,
   $ssl              = $ldap::params::server_ssl,
   $ssl_cacert       = $ldap::params::server_ssl_cacert,
   $ssl_cert         = $ldap::params::server_ssl_cert,
   $ssl_key          = $ldap::params::server_ssl_key,
+  $ssl_verify_client = $ldap::params::server_ssl_verify_client,
+  $kerberos          = $ldap::params::server_kerberos,
+  $krb5_keytab       = $ldap::params::server_krb5_keytab,
+  $krb5_ticket_cache = $ldap::params::server_krb5_ticket_cache,
   $config           = $ldap::params::config,
   $monitor          = $ldap::params::monitor,
   $bind_anon        = $ldap::params::server_bind_anon,
@@ -160,9 +223,44 @@ class ldap::server (
       validate_absolute_path($ssl_cert)
     }
     validate_absolute_path($ssl_key)
+    if $ssl_verify_client {
+      validate_re($ssl_verify_client, ['never', 'allow', 'try', 'demand', 'hard', 'true'])
+    }
+  }
+
+  validate_bool($kerberos)
+  if $kerberos {
+    validate_string($krb5_keytab)
+    validate_string($krb5_ticket_cache)
   }
   validate_bool($bind_anon)
   validate_bool($bind_v2)
+
+  validate_array($access)
+
+  # if sync provider is given, make access readonly by default but allow override
+  # via parameter using e.g. hiera lookup hierarchy
+  $access_writeable_on_sync_provider_only_cfg =
+    $access_writeable_on_sync_provider_only ? {
+    default => $access_writeable_on_sync_provider_only,
+    undef => $sync_provider ? {
+      default => "read",
+      undef => "write",
+    }
+  }
+  if $access_writeable_on_sync_provider_only_cfg {
+    validate_string($access_writeable_on_sync_provider_only_cfg)
+  }
+
+  # use what was determined for consumer writeablility above for ldap root
+  # access by default but allow override via parameter
+  $access_for_ldapi_rootdn_cfg = $access_for_ldapi_rootdn ? {
+    default => $access_for_ldapi_rootdn,
+    undef => $access_writeable_on_sync_provider_only_cfg,
+  }
+  if $access_for_ldapi_rootdn_cfg {
+    validate_string($access_for_ldapi_rootdn_cfg)
+  }
 
   anchor { 'ldap::server::begin': } ->
   class { '::ldap::server::install': } ->

--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -6,7 +6,8 @@ class ldap::server::config inherits ldap::server {
   file { $ldap::server::config_file:
     owner   => $ldap::server::ldapowner,
     group   => $ldap::server::ldapgroup,
-    mode    => '0644',
+    # may contain passwords
+    mode    => '0400',
     content => template($ldap::server::config_template),
   }
 

--- a/spec/unit/classes/ldap_server_spec.rb
+++ b/spec/unit/classes/ldap_server_spec.rb
@@ -32,8 +32,8 @@ describe 'ldap::server', :type => :class do
     )}
 
     it { should contain_file('/etc/ldap/slapd.conf').with(
-      :owner   => '0',
-      :group   => '0',
+      :owner   => 'openldap',
+      :group   => 'openldap',
       :mode    => '0400'
     )}
 
@@ -66,8 +66,8 @@ describe 'ldap::server', :type => :class do
     )}
 
     it { should contain_file('/etc/openldap/slapd.conf').with(
-      :owner   => '0',
-      :group   => '0',
+      :owner   => 'ldap',
+      :group   => 'ldap',
       :mode    => '0400'
     )}
 

--- a/spec/unit/classes/ldap_server_spec.rb
+++ b/spec/unit/classes/ldap_server_spec.rb
@@ -34,7 +34,7 @@ describe 'ldap::server', :type => :class do
     it { should contain_file('/etc/ldap/slapd.conf').with(
       :owner   => '0',
       :group   => '0',
-      :mode    => '0644'
+      :mode    => '0400'
     )}
 
     it { should contain_file('/etc/default/slapd').with(
@@ -68,7 +68,7 @@ describe 'ldap::server', :type => :class do
     it { should contain_file('/etc/openldap/slapd.conf').with(
       :owner   => '0',
       :group   => '0',
-      :mode    => '0644'
+      :mode    => '0400'
     )}
 
     it { should contain_file('/etc/sysconfig/ldap').with(
@@ -101,7 +101,7 @@ describe 'ldap::server', :type => :class do
     it { should contain_file('/etc/openldap/slapd.conf').with(
       :owner   => '_openldap',
       :group   => '_openldap',
-      :mode    => '0644'
+      :mode    => '0400'
     )}
 
     it { should_not contain_file('/etc/sysconfig/ldap').with(

--- a/templates/debian/defaults.erb
+++ b/templates/debian/defaults.erb
@@ -34,5 +34,18 @@ SLAPD_SERVICES="ldap:/// ldapi:///"
 # when you don't want to edit a configuration file.
 SLAPD_SENTINEL_FILE=/etc/ldap/noslapd
 
+# For Kerberos authentication (via SASL), slapd by default uses the system
+# keytab file (/etc/krb5.keytab).  To use a different keytab file,
+# uncomment this line and change the path.
+#export KRB5_KTNAME=/etc/krb5.keytab
+<% if @kerberos -%>
+<%   if @krb5_keytab -%>
+export KRB5_KTNAME=<%= @krb5_keytab %>
+<%   end -%>
+<%   if @krb5_ticket_cache -%>
+export KRB5CCNAME=<%= @krb5_ticket_cache %>
+<%   end -%>
+<% end -%>
+
 # Additional options to pass to slapd
 SLAPD_OPTIONS=""

--- a/templates/slapd.conf.erb
+++ b/templates/slapd.conf.erb
@@ -29,7 +29,35 @@ moduleload <%= m %>
 TLSCACertificateFile   <%= @ssl_cacert %>
 TLSCertificateFile     <%= @ssl_cert %>
 TLSCertificateKeyFile  <%= @ssl_key %>
+<%   if @ssl_verify_client -%>
+TLSVerifyClient        <%= @ssl_verify_client %>
+<%   end -%>
 <% end -%>
+
+# Access control ...
+access to dn.exact=""
+  by dn.exact="gidNumber=0+uidNumber=0,cn=peercred,cn=external,cn=auth" <%= @access_for_ldapi_rootdn_cfg %>
+  by * read
+access to dn.exact="cn=Subschema"
+  by * read
+
+<% @access.each do |torule| -%>
+<%   torule.each do |what,byrules| -%>
+access to <%= what %>
+  by dn.exact="gidNumber=0+uidNumber=0,cn=peercred,cn=external,cn=auth" <%= @access_for_ldapi_rootdn_cfg %>
+<%     byrules.each do |byrule| -%>
+<%       byrule.each do |who, access| -%>
+<%         access.sub!('@@writeable_on_sync_provider_only@@', @access_writeable_on_sync_provider_only_cfg) -%>
+  by <%= who %> <%= access %>
+<%       end -%>
+<%     end -%>
+<%   end -%>
+  by * none
+<% end -%>
+
+access to *
+  by dn.exact="gidNumber=0+uidNumber=0,cn=peercred,cn=external,cn=auth" <%= @access_for_ldapi_rootdn_cfg %>
+  by * none
 
 <% if @config == true -%>
 # Define a config database (cn=config)


### PR DESCRIPTION
Provide flexible way to configure ACLs. Account for different needs on
provider (master) and consumer (slave) in access rights. Allow
configuration of SSL and Kerberos authentication at the server. Secure
slapd.conf file.