### PR TITLE
Add option to get rid of slapd.d dynamic config

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -128,9 +128,12 @@ class ldap::params {
 
   $client_config_file         = "${ldap_config_directory}/ldap.conf"
   $server_config_file         = "${ldap_config_directory}/slapd.conf"
+  $server_dynconfig_directory = "${ldap_config_directory}/slapd.d"
   $server_schema_directory    = "${ldap_config_directory}/schema"
   $pidfile                    = "${server_run_directory}/slapd.pid"
   $argsfile                   = "${server_run_directory}/slapd.args"
+
+  $server_purge_dynconfig_dir = false
 
   $server_kerberos            = false
   $server_krb5_keytab         = "${ldap_config_directory}/ldap.keytab"

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -118,6 +118,13 @@
 # [*access_for_ldapi_rootdn*]
 #   What access to grant to the LDAPI access DN. Default: write.
 #
+# [*dynconfig_directory*]
+#   Path to the slapd.d cn=config backend directory.
+#
+# [*purge_dynconfig_directory*]
+#   Whether to delete the cn=config backend directory to make sure that
+#   slapd.conf is used. Default: false.
+#
 # [*config*]
 #   Whether the config database should be built (cn=config).
 #
@@ -193,6 +200,8 @@ class ldap::server (
   $service_enable   = $ldap::params::server_service_enable,
   $service_ensure   = $ldap::params::server_service_ensure,
   $config_directory = $ldap::params::ldap_config_directory,
+  $dynconfig_directory = $ldap::params::server_dynconfig_directory,
+  $purge_dynconfig_dir = $ldap::params::purge_dynconfig_dir,
   $config_file      = $ldap::params::server_config_file,
   $config_template  = $ldap::params::server_config_template,
   $default_file     = $ldap::params::server_default_file,
@@ -218,6 +227,10 @@ class ldap::server (
   validate_absolute_path($schema_directory)
   validate_absolute_path($config_directory)
   validate_string($schema_source_directory)
+  validate_bool($purge_dynconfig_dir)
+  if ($purge_dynconfig_dir) {
+    validate_absolute_path($dynconfig_directory)
+  }
   validate_array($modules)
   validate_array($indexes)
   validate_array($overlays)

--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -48,4 +48,14 @@ class ldap::server::config inherits ldap::server {
       require => File[$ldap::server::directory],
     }
   }
+
+  if $ldap::server::dynconfig_directory and $ldap::server::purge_dynconfig_dir == true {
+    file { $ldap::server::dynconfig_directory:
+      path => $ldap::server::dynconfig_directory,
+      ensure => absent,
+      recurse => true,
+      purge => true,
+      force => true,
+     }
+   }
 }


### PR DESCRIPTION
With $purge_dynconfig_dir the user can make sure that the slapd.d
directory is purged and stays gone even after package updates. That
makes sure that the server doesn't silently load a completely different
configuration that what's in slapd.conf.