### PR TITLE
Fix extra schema import

### DIFF
--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -29,7 +29,7 @@ class ldap::server::config inherits ldap::server {
   ->
   ldap::schema_file { $ldap::server::extra_schemas:
     directory => $ldap::server::schema_directory,
-    source    => $ldap::server::schema_source_directory,
+    source_directory => $ldap::server::schema_source_directory,
   }
 
   file { $ldap::server::directory:


### PR DESCRIPTION
The wrong property was used to specify the extra schema source
directory, resulting in the extra schema files being created as
empty directories by puppet.

Sorry, got screwed up somehow in transit between testing and upstreaming.