### PR TITLE
Autorequire the ldap-server service in ldap_entry type

### DIFF
--- a/lib/puppet/type/ldap_entry.rb
+++ b/lib/puppet/type/ldap_entry.rb
@@ -100,5 +100,7 @@ Puppet::Type.newtype(:ldap_entry) do
     parent = self[:name].split(",").drop(1).join(",")
     parent
   end
+  # The server has to run before we can add entries to the database
+  autorequire(:service) { 'ldap-server' }
 
 end


### PR DESCRIPTION
For me, while provisioning my system, puppet always tried to create the entries in ldap database before the ldap server was running. So, it only succeeded on second puppet run, because then the slapd was running.

For that reason, the added autorequire takes care, that the service, if managed, is started before the ldap_entry resources are called.

hope you like it.

Sebastian