### PR TITLE
Fix and extend syncrepl support

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -69,6 +69,7 @@ class ldap::params {
   $server_sync_provider       = undef
   $server_sync_type           = undef
   $server_sync_interval       = undef
+  $server_sync_retry          = undef
   $server_sync_filter         = undef
   $server_sync_scope          = undef
   $server_sync_attrs          = undef
@@ -76,6 +77,11 @@ class ldap::params {
   $server_sync_bindmethod     = undef
   $server_sync_binddn         = undef
   $server_sync_credentials    = undef
+  $server_sync_saslmech       = undef
+  $server_sync_tls_cert       = undef
+  $server_sync_tls_key        = undef
+  $server_sync_tls_cacert     = undef
+  $server_sync_tls_reqcert    = undef
 
   $gem_ensure       = 'present'
 

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -67,6 +67,9 @@
 # [*sync_interval*]
 #   Synchronization interval.
 #
+# [*sync_retry*]
+#   Synchronization retries
+#
 # [*sync_filter*]
 #   Search filter for synchronization.
 #
@@ -87,6 +90,21 @@
 #
 # [*sync_credentials*]
 #   Simple bind credentials for provider.
+#
+# [*sync_saslmech*]
+#   SASL mechanism for syncrepl replication.
+#
+# [*sync_tls_cert*]
+#   X.509 client certificate for syncrepl replication.
+#
+# [*sync_tls_key*]
+#   X.509 private key for syncrepl replication.
+#
+# [*sync_tls_cacert*]
+#   X.509 ca certificate for syncrepl replication.
+#
+# [*sync_tls_reqcert*]
+#   requirement of server certificat verification
 #
 # [*ssl*]
 #   Whether the server should listen on port 636 (SSL).
@@ -222,6 +240,7 @@ class ldap::server (
   $sync_searchbase     = undef,
   $sync_type           = $ldap::params::server_sync_type,
   $sync_interval       = $ldap::params::server_sync_interval,
+  $sync_retry          = $ldap::params::server_sync_retry,
   $sync_filter         = $ldap::params::server_sync_filter,
   $sync_scope          = $ldap::params::server_sync_scope,
   $sync_attrs          = $ldap::params::server_sync_attrs,
@@ -229,6 +248,12 @@ class ldap::server (
   $sync_bindmethod     = $ldap::params::server_sync_bindmethod,
   $sync_binddn         = $ldap::params::server_sync_binddn,
   $sync_credentials    = $ldap::params::server_sync_credentials,
+  $sync_bindmethod     = $ldap::params::server_sync_bindmethod,
+  $sync_saslmech       = $ldap::params::server_sync_saslmech,
+  $sync_tls_cert       = $ldap::params::server_sync_tls_cert,
+  $sync_tls_key        = $ldap::params::server_sync_tls_key,
+  $sync_tls_cacert     = $ldap::params::server_sync_tls_cacert,
+  $sync_tls_reqcert    = $ldap::params::server_sync_tls_reqcert,
   $access           = $ldap::params::server_access,
   $access_writeable_on_sync_provider_only = undef,
   $access_for_ldapi_rootdn = undef,
@@ -323,6 +348,9 @@ class ldap::server (
   if $sync_interval {
     validate_string($sync_interval)
   }
+  if $sync_retry {
+    validate_string($sync_retry)
+  }
   if $sync_filter {
     validate_string($sync_filter)
   }
@@ -340,6 +368,21 @@ class ldap::server (
   }
   if $sync_credentials {
     validate_string($sync_credentials)
+  }
+  if $sync_saslmech {
+    validate_string($sync_saslmech)
+  }
+  if $sync_tls_cert {
+    validate_string($sync_tls_cert)
+  }
+  if $sync_tls_key {
+    validate_string($sync_tls_key)
+  }
+  if $sync_tls_cacert {
+    validate_string($sync_tls_cacert)
+  }
+  if $sync_tls_reqcert {
+    validate_string($sync_tls_reqcert)
   }
 
   # use sync provider as master uri if not explicitly set

--- a/templates/slapd.conf.erb
+++ b/templates/slapd.conf.erb
@@ -112,6 +112,9 @@ syncrepl
 <% if @sync_interval -%>
   interval=<%= @sync_interval %>
 <% end -%>
+<% if @sync_retry -%>
+  retry="<%= @sync_retry %>"
+<% end -%>
 <% if @sync_filter -%>
   filter=<%= @sync_filter %>
 <% end -%>
@@ -127,9 +130,26 @@ syncrepl
 <% if @sync_bindmethod -%>
   bindmethod=<%= @sync_bindmethod %>
 <% end -%>
-<% if not @bind_method or @sync_bindmethod == "simple" -%>
+<% if not @sync_bindmethod or @sync_bindmethod == "simple" -%>
   binddn=<%= @sync_binddn %>
   credentials=<%= @sync_credentials %>
+<% end -%>
+<% if @sync_bindmethod == "sasl" -%>
+  saslmech=<%= @sync_saslmech %>
+<%   if @sync_saslmech == "EXTERNAL" -%>
+<%     if @sync_tls_cert -%>
+  tls_cert=<%= @sync_tls_cert %>
+<%     end -%>
+<%     if @sync_tls_key -%>
+  tls_key=<%= @sync_tls_key %>
+<%     end -%>
+<%   end -%>
+<% end -%>
+<% if @sync_tls_cacert -%>
+  tls_cacert=<%= @sync_tls_cacert %>
+<% end -%>
+<% if @sync_tls_reqcert -%>
+  tls_reqcert=<%= @sync_tls_reqcert %>
 <% end -%>
 
 updateref <%= @sync_master_uri_cfg %>


### PR DESCRIPTION
Fix sync_bindmethod logic in template. Add additional syncrepl options,
mostly for SASL/EXTERNAL (i.e. TLS client certificate) authentication.