### PR TITLE
Make rootpw optional

### DIFF
--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -201,7 +201,7 @@
 class ldap::server (
   $suffix,
   $rootdn,
-  $rootpw,
+  $rootpw           = undef,
   $configdn         = $rootdn,
   $configpw         = $rootpw,
   $monitordn        = $rootdn,

--- a/templates/slapd.conf.erb
+++ b/templates/slapd.conf.erb
@@ -93,7 +93,9 @@ database  <%= @backend %>
 directory <%= @directory %>
 suffix    "<%= @suffix %>"
 rootdn    "<%= @rootdn %>"
+<% if @rootpw %>
 rootpw    "<%= @rootpw %>"
+<% end -%>
 
 # Overlays
 <% @overlays.each do |o| -%>


### PR DESCRIPTION
The rootpw is not actually required and a potential security risk.