### PR TITLE
Make package dependency management configurable

### DIFF
--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -31,6 +31,20 @@
 # [*ssl_ciphersuite*]
 #   specify tls ciphersuite.
 #
+# [*manage_package_dependencies*]
+#   Whether to automatically install additional software packages such as
+#   net-ldap (Default: true).
+#
+# [*net_ldap_package_name*]
+#   The name of the net-ldap package to install (Default: OS-dependant
+#   ruby-net-ldap or net-ldap).
+#
+# [*net_ldap_package_ensure*]
+#   The ensure of the net-ldap package (Default: present).
+#
+# [*net_ldap_package_provider*]
+#  The provider of the net-ldap package (Default: OS-dependant apt or gem).
+#
 # [*sizelimit*]
 #   Maximum number of entries to return by default.
 #
@@ -59,8 +73,10 @@ class ldap::client (
   $config_directory = $ldap::params::ldap_config_directory,
   $config_file      = $ldap::params::client_config_file,
   $config_template  = $ldap::params::client_config_template,
-  $gem_name         = $ldap::params::gem_name,
-  $gem_ensure       = $ldap::params::gem_ensure,
+  $manage_package_dependencies = $ldap::params::manage_package_dependencies,
+  $net_ldap_package_name       = $ldap::params::net_ldap_package_name,
+  $net_ldap_package_ensure     = $ldap::params::net_ldap_package_ensure,
+  $net_ldap_package_provider   = $ldap::params::net_ldap_package_provider,
   $sizelimit        = $ldap::params::client_sizelimit,
   $timelimit        = $ldap::params::client_timelimit,
 ) inherits ldap::params {
@@ -88,6 +104,11 @@ class ldap::client (
       validate_re($ssl_reqcert, ['never', 'allow', 'try', 'demand'])
     }
   }
+
+  validate_bool($manage_package_dependencies)
+  validate_string($net_ldap_package_name)
+  validate_string($net_ldap_package_ensure)
+  validate_string($net_ldap_package_provider)
 
   anchor { 'ldap::client::begin': } ->
   class { '::ldap::client::install': } ->

--- a/manifests/client/install.pp
+++ b/manifests/client/install.pp
@@ -8,13 +8,15 @@ class ldap::client::install inherits ldap::client {
     name   => $ldap::client::package_name,
   }
 
-  package { 'ruby':
-    ensure => present,
-  } ->
+  if $ldap::client::manage_package_dependencies {
+    package { 'ruby':
+      ensure => present,
+    } ->
 
-  package { 'ldap-gem':
-    ensure   => $ldap::client::gem_ensure,
-    name     => $ldap::client::gem_name,
-    provider => 'gem',
+    package { 'net-ldap':
+      ensure   => $ldap::client::net_ldap_package_ensure,
+      name     => $ldap::client::net_ldap_package_name,
+      provider => $ldap::client::net_ldap_package_provider,
+    }
   }
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -90,7 +90,8 @@ class ldap::params {
   $server_memberof_group_oc   = undef
   $server_refint_attributes   = undef
 
-  $gem_ensure       = 'present'
+  $manage_package_dependencies = true
+  $net_ldap_package_ensure     = 'present'
 
   case $::osfamily {
     'Debian': {
@@ -108,7 +109,8 @@ class ldap::params {
       $server_default_file     = "${os_config_directory}/slapd"
       $server_default_template = 'ldap/debian/defaults.erb'
       $server_directory        = '/var/lib/ldap'
-      $gem_name                = 'net-ldap'
+      $net_ldap_package_name     = 'ruby-net-ldap'
+      $net_ldap_package_provider = 'apt'
     }
     'OpenBSD': {
       $ldap_config_directory   = '/etc/openldap'
@@ -125,7 +127,8 @@ class ldap::params {
       $server_default_file     = undef
       $server_default_template = undef
       $server_directory        = '/var/openldap-data'
-      $gem_name                = 'net-ldap'
+      $net_ldap_package_name     = 'net-ldap'
+      $net_ldap_package_provider = 'gem'
     }
     'RedHat': {
       $ldap_config_directory   = '/etc/openldap'
@@ -142,7 +145,8 @@ class ldap::params {
       $server_default_file     = "${os_config_directory}/ldap"
       $server_default_template = 'ldap/redhat/sysconfig.erb'
       $server_directory        = '/var/lib/ldap'
-      $gem_name                = 'net-ldap'
+      $net_ldap_package_name     = 'net-ldap'
+      $net_ldap_package_provider = 'gem'
     }
     default: {
       fail("${::operatingsystem} not supported")

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -304,8 +304,6 @@ class ldap::server (
   $default_template = $ldap::params::server_default_template,
   $db_config_file     = $ldap::params::server_db_config_file,
   $db_config_template = $ldap::params::server_db_config_template,
-  $gem_name         = $ldap::params::gem_name,
-  $gem_ensure       = $ldap::params::gem_ensure,
   $ldapowner        = $ldap::params::ldapowner,
   $ldapgroup        = $ldap::params::ldapgroup,
   $memberof_group_oc = $ldap::params::server_memberof_group_oc,


### PR DESCRIPTION
Allow to disable automatic installation of dependency packages. Allow to
override package provider. Change default package provider for
Debian/Ubuntu to apt because they have a ruby-net-ldap package and a
packaging policy not to use ruby gems. This also avoids a silent
dependency on Internet connectivity.