### PR TITLE
To unable olc setting

### DIFF
--- a/templates/slapd.conf.erb
+++ b/templates/slapd.conf.erb
@@ -76,7 +76,7 @@ access to *
 # Define a config database (cn=config)
 
 database config
-suffix "cn=config"
+#suffix "cn=config"
 rootdn    "<%= @configdn %>"
 rootpw    "<%= @configpw %>"
 

--- a/templates/slapd.conf.erb
+++ b/templates/slapd.conf.erb
@@ -78,7 +78,6 @@ access to *
 # Define a config database (cn=config)
 
 database config
-#suffix "cn=config"
 rootdn    "<%= @configdn %>"
 rootpw    "<%= @configpw %>"
 

--- a/templates/slapd.conf.erb
+++ b/templates/slapd.conf.erb
@@ -6,6 +6,8 @@ loglevel <%= @log_level %>
 <% if @bind_anon == true -%>
 # Allow anonymous bind
 allow bind_anon_dn
+<% else -%>
+disallow bind_anon
 <% end -%>
 
 <% if @bind_v2 == true -%>


### PR DESCRIPTION
On debian suffix should be removed
then in hiera
ldap::server::config: true
ldap::server::configdn: "cn=admin,cn=config"