### PR TITLE
No rootpw and ACLs in config/monitor DBs

### DIFF
--- a/templates/slapd.conf.erb
+++ b/templates/slapd.conf.erb
@@ -79,12 +79,6 @@ access to *
 
 database config
 rootdn    "<%= @_configdn %>"
-#rootpw    "<%= @_configpw %>"
-
-#access to *
-#        by dn.exact="gidNumber=0+uidNumber=0,cn=peercred,cn=external,cn=auth" manage
-#        by dn.exact="<%= @_configdn %>" manage
-#        by * none
 
 <% end -%>
 <% if @monitor == true -%>
@@ -93,13 +87,7 @@ rootdn    "<%= @_configdn %>"
 # - database is unwriteable.
 
 database monitor
-# suffix    "cn=Monitor"
 rootdn    "<%= @_monitordn %>"
-# rootpw    "<%= @_monitorpw %>"
-#access to *
-#  by dn.exact="gidNumber=0+uidNumber=0,cn=peercred,cn=external,cn=auth" read
-#  by dn.exact="<%= @_monitordn %>" read
-#  by * none
 <% end -%>
 
 # Database definition

--- a/templates/slapd.conf.erb
+++ b/templates/slapd.conf.erb
@@ -79,12 +79,12 @@ access to *
 
 database config
 rootdn    "<%= @_configdn %>"
-rootpw    "<%= @_configpw %>"
+#rootpw    "<%= @_configpw %>"
 
-access to *
-        by dn.exact="gidNumber=0+uidNumber=0,cn=peercred,cn=external,cn=auth" manage
-        by dn.exact="<%= @_configdn %>" manage
-        by * none
+#access to *
+#        by dn.exact="gidNumber=0+uidNumber=0,cn=peercred,cn=external,cn=auth" manage
+#        by dn.exact="<%= @_configdn %>" manage
+#        by * none
 
 <% end -%>
 <% if @monitor == true -%>
@@ -93,13 +93,13 @@ access to *
 # - database is unwriteable.
 
 database monitor
-# suffix "cn=Monitor"
+# suffix    "cn=Monitor"
 rootdn    "<%= @_monitordn %>"
-rootpw    "<%= @_monitorpw %>"
-access to *
-  by dn.exact="gidNumber=0+uidNumber=0,cn=peercred,cn=external,cn=auth" read
-  by dn.exact="<%= @_monitordn %>" read
-  by * none
+# rootpw    "<%= @_monitorpw %>"
+#access to *
+#  by dn.exact="gidNumber=0+uidNumber=0,cn=peercred,cn=external,cn=auth" read
+#  by dn.exact="<%= @_monitordn %>" read
+#  by * none
 <% end -%>
 
 # Database definition


### PR DESCRIPTION
* rootpw is not allowed in config/monitor DBs
* OpenLDAP throws warnings when included ACLs are included:
`rootdn is always granted unlimited privileges`