### PR TITLE
Make modes of config files and directories configurable

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -95,56 +95,65 @@ class ldap::params {
 
   case $::osfamily {
     'Debian': {
-      $ldap_config_directory   = '/etc/ldap'
-      $os_config_directory     = '/etc/default'
-      $server_run_directory    = '/var/run/slapd'
+      $ldap_config_directory     = '/etc/ldap'
+      $os_config_directory       = '/etc/default'
+      $server_run_directory      = '/var/run/slapd'
+      $server_run_directory_mode = '0700'
 
-      $client_package_name     = 'libldap-2.4-2'
+      $client_package_name       = 'libldap-2.4-2'
 
-      $ldapowner               = 'openldap'
-      $ldapgroup               = 'openldap'
+      $ldapowner                 = 'openldap'
+      $ldapgroup                 = 'openldap'
 
-      $server_package_name     = 'slapd'
-      $server_service_name     = 'slapd'
-      $server_default_file     = "${os_config_directory}/slapd"
-      $server_default_template = 'ldap/debian/defaults.erb'
-      $server_directory        = '/var/lib/ldap'
+      $server_package_name       = 'slapd'
+      $server_service_name       = 'slapd'
+      $server_default_file       = "${os_config_directory}/slapd"
+      $server_default_file_mode  = '0644'
+      $server_default_template   = 'ldap/debian/defaults.erb'
+      $server_directory          = '/var/lib/ldap'
+      $server_directory_mode     = '0700'
       $net_ldap_package_name     = 'ruby-net-ldap'
       $net_ldap_package_provider = 'apt'
     }
     'OpenBSD': {
-      $ldap_config_directory   = '/etc/openldap'
-      $os_config_directory     = undef
-      $server_run_directory    = '/var/run/openldap'
+      $ldap_config_directory     = '/etc/openldap'
+      $os_config_directory       = undef
+      $server_run_directory      = '/var/run/openldap'
+      $server_run_directory_mode = '0755'
 
-      $client_package_name     = 'openldap-client'
+      $client_package_name       = 'openldap-client'
 
-      $ldapowner               = '_openldap'
-      $ldapgroup               = '_openldap'
+      $ldapowner                 = '_openldap'
+      $ldapgroup                 = '_openldap'
 
-      $server_package_name     = 'openldap-server'
-      $server_service_name     = 'slapd'
-      $server_default_file     = undef
-      $server_default_template = undef
-      $server_directory        = '/var/openldap-data'
+      $server_package_name       = 'openldap-server'
+      $server_service_name       = 'slapd'
+      $server_default_file       = undef
+      $server_default_file_mode  = undef
+      $server_default_template   = undef
+      $server_directory          = '/var/openldap-data'
+      $server_directory_mode     = '0700'
       $net_ldap_package_name     = 'net-ldap'
       $net_ldap_package_provider = 'gem'
     }
     'RedHat': {
-      $ldap_config_directory   = '/etc/openldap'
-      $os_config_directory     = '/etc/sysconfig'
-      $server_run_directory    = '/var/run/openldap'
+      $ldap_config_directory     = '/etc/openldap'
+      $os_config_directory       = '/etc/sysconfig'
+      $server_run_directory      = '/var/run/openldap'
+      $server_run_directory_mode = '0700'
 
-      $client_package_name     = 'openldap-clients'
+      $client_package_name       = 'openldap-clients'
 
-      $ldapowner               = 'ldap'
-      $ldapgroup               = 'ldap'
+      $ldapowner                 = 'ldap'
+      $ldapgroup                 = 'ldap'
 
-      $server_package_name     = 'openldap-servers'
-      $server_service_name     = 'slapd'
-      $server_default_file     = "${os_config_directory}/ldap"
-      $server_default_template = 'ldap/redhat/sysconfig.erb'
-      $server_directory        = '/var/lib/ldap'
+      $server_package_name       = 'openldap-servers'
+      $server_service_name       = 'slapd'
+      $server_default_file       = "${os_config_directory}/ldap"
+      $server_default_file_mode  = '0644'
+      $server_default_template   = 'ldap/redhat/sysconfig.erb'
+      $server_directory          = '/var/lib/ldap'
+      $server_directory_mode     = '0700'
       $net_ldap_package_name     = 'net-ldap'
       $net_ldap_package_provider = 'gem'
     }
@@ -153,12 +162,14 @@ class ldap::params {
     }
   }
 
-  $client_config_file         = "${ldap_config_directory}/ldap.conf"
-  $server_config_file         = "${ldap_config_directory}/slapd.conf"
-  $server_dynconfig_directory = "${ldap_config_directory}/slapd.d"
-  $server_schema_directory    = "${ldap_config_directory}/schema"
-  $pidfile                    = "${server_run_directory}/slapd.pid"
-  $argsfile                   = "${server_run_directory}/slapd.args"
+  $client_config_file           = "${ldap_config_directory}/ldap.conf"
+  $server_config_file           = "${ldap_config_directory}/slapd.conf"
+  $server_config_file_mode      = '0400'
+  $server_dynconfig_directory   = "${ldap_config_directory}/slapd.d"
+  $server_schema_directory      = "${ldap_config_directory}/schema"
+  $server_schema_directory_mode = '0755'
+  $pidfile                      = "${server_run_directory}/slapd.pid"
+  $argsfile                     = "${server_run_directory}/slapd.args"
 
   $server_purge_dynconfig_directory = false
 
@@ -167,6 +178,7 @@ class ldap::params {
   $server_krb5_ticket_cache   = "${ldap_config_directory}/ldap.krb5cc"
 
   $server_db_config_file      = "${server_directory}/DB_CONFIG"
+  $server_db_config_file_mode = '0644'
   $server_db_config_template  = 'ldap/DB_CONFIG.erb'
 
   $server_sizelimit                 = '500'

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -13,8 +13,29 @@
 # [*rootpw*]
 #   The password for the rootdn administrative user.
 #
+# [*config_file*]
+#   Location of the server configuration file.
+#
+# [*config_file_mode*]
+#   Permissions of the server configuration file.
+#
+# [*default_file*]
+#   Location of the OS OpenLDAP server defaults file.
+#
+# [*default_file_mode*]
+#   Permission of the OS OpenLDAP server defaults file.
+#
+# [*db_config_file*]
+#   Location of the DB_CONFIG file.
+#
+# [*db_config_file_mode*]
+#   Permission of the DB_CONFIG file.
+#
 # [*directory*]
 #   Path to where the slapd database files should be stored.
+#
+# [*directory_mode*]
+#   Permissions of the path to where the slapd database files should be stored.
 #
 # [*ldapowner*]
 #   The owner of the slapd and database configuration files.
@@ -34,8 +55,17 @@
 # [*extra_schemas*]
 #   An array of schema files which should be importe from the master and loaded in.
 #
+# [*run_directory*]
+#   Directory where OpenLDAP stores run time information, i.e. PID file.
+#
+# [*run_directory_mode*]
+#   Permissions of the directory where OpenLDAP stores run time information, i.e. PID file.
+#
 # [*schema_directory*]
 #   Directory to import the extra schema files into.
+#
+# [*schema_directory_mode*]
+#   Permissions of the directory to import the extra schema files into.
 #
 # [*schema_source_directory*]
 #   Directory to import the extra schema files from, usually a puppet:///files source.
@@ -251,12 +281,16 @@ class ldap::server (
   $monitordn        = undef,
   $monitorpw        = undef,
   $directory        = $ldap::params::server_directory,
+  $directory_mode   = $ldap::params::server_directory_mode,
   $backend          = $ldap::params::server_backend,
   $log_level        = $ldap::params::server_log_level,
   $schemas          = $ldap::params::server_schemas,
   $extra_schemas    = $ldap::params::server_extra_schemas,
   $schema_directory = $ldap::params::server_schema_directory,
+  $schema_directory_mode   = $ldap::params::server_schema_directory_mode,
   $schema_source_directory = $ldap::params::server_schema_source_directory,
+  $run_directory           = $ldap::params::server_run_directory,
+  $run_directory_mode      = $ldap::params::server_run_directory_mode,
   $modules          = $ldap::params::server_modules,
   $indexes          = $ldap::params::server_indexes,
   $overlays         = $ldap::params::server_overlays,
@@ -308,17 +342,21 @@ class ldap::server (
   $dynconfig_directory = $ldap::params::server_dynconfig_directory,
   $purge_dynconfig_directory = $ldap::params::server_purge_dynconfig_directory,
   $config_file      = $ldap::params::server_config_file,
-  $config_template  = $ldap::params::server_config_template,
-  $default_file     = $ldap::params::server_default_file,
-  $default_template = $ldap::params::server_default_template,
-  $db_config_file     = $ldap::params::server_db_config_file,
-  $db_config_template = $ldap::params::server_db_config_template,
-  $ldapowner        = $ldap::params::ldapowner,
-  $ldapgroup        = $ldap::params::ldapgroup,
-  $memberof_group_oc = $ldap::params::server_memberof_group_oc,
-  $refint_attributes = $ldap::params::server_refint_attributes,
-  $sizelimit         = $ldap::params::server_sizelimit,
-  $timelimit         = $ldap::params::server_timelimit
+  $config_file_mode = $ldap::params::server_config_file_mode,
+
+  $config_template     = $ldap::params::server_config_template,
+  $default_file        = $ldap::params::server_default_file,
+  $default_file_mode   = $ldap::params::server_default_file_mode,
+  $default_template    = $ldap::params::server_default_template,
+  $db_config_file      = $ldap::params::server_db_config_file,
+  $db_config_file_mode = $ldap::params::server_db_config_file_mode,
+  $db_config_template  = $ldap::params::server_db_config_template,
+  $ldapowner           = $ldap::params::ldapowner,
+  $ldapgroup           = $ldap::params::ldapgroup,
+  $memberof_group_oc   = $ldap::params::server_memberof_group_oc,
+  $refint_attributes   = $ldap::params::server_refint_attributes,
+  $sizelimit           = $ldap::params::server_sizelimit,
+  $timelimit           = $ldap::params::server_timelimit
 ) inherits ldap::params {
 
   include stdlib

--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -41,7 +41,7 @@ class ldap::server::config inherits ldap::server {
     owner   => $ldap::server::ldapowner,
     group   => $ldap::server::ldapgroup,
     # may contain passwords
-    mode    => '0400',
+    mode    => $ldap::server::config_file_mode,
     content => template($ldap::server::config_template),
   }
 
@@ -49,7 +49,7 @@ class ldap::server::config inherits ldap::server {
     file { $ldap::server::default_file:
       owner   => 0,
       group   => 0,
-      mode    => '0644',
+      mode    => $ldap::server::default_file_mode,
       content => template($ldap::server::default_template),
     }
   }
@@ -58,7 +58,7 @@ class ldap::server::config inherits ldap::server {
     ensure => directory,
     owner  => 0,
     group  => 0,
-    mode   => '0755',
+    mode   => $ldap::server::schema_directory_mode,
   }
   ->
   ldap::schema_file { $ldap::server::extra_schemas:
@@ -70,21 +70,21 @@ class ldap::server::config inherits ldap::server {
     ensure => directory,
     owner  => $ldap::server::ldapowner,
     group  => $ldap::server::ldapgroup,
-    mode   => '0700',
+    mode   => $ldap::server::directory_mode,
   }
 
-  file { $ldap::server::server_run_directory:
+  file { $ldap::server::run_directory:
     ensure => directory,
     owner  => $ldap::server::ldapowner,
     group  => $ldap::server::ldapgroup,
-    mode   => '0700',
+    mode   => $ldap::server::run_directory_mode,
   }
 
   if $ldap::server::backend == 'bdb' or $ldap::server::backend == 'hdb' {
     file { $ldap::server::db_config_file:
       owner   => $ldap::server::ldapowner,
       group   => $ldap::server::ldapgroup,
-      mode    => '0644',
+      mode    => $ldap::server::db_config_file_mode,
       content => template($ldap::server::db_config_template),
       require => File[$ldap::server::directory],
     }


### PR DESCRIPTION
Since merge commit f73425725abba470a4fb1326cba4c39dcc737bf3, at least for me on OpenBSD, on every Puppet run, the mode of the run directory is reset from 0700 to 0755. Therefore, change the mode of the run directory to 0755.

If preferred, I could change it to be OS dependent in the params.pp.

