### PR TITLE
Allow Mutable Attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,8 +96,10 @@ ldap_entry { 'cn=Foo,ou=Bar,dc=baz,dc=co,dc=uk':
   base        => 'dc=baz,dc=co,dc=uk',
   username    => 'cn=admin,dc=baz,dc=co,dc=uk',
   password    => 'password',
-  attributes  => { givenName   => 'Foo',
-                   objectClass => ["top", "person", "inetorgPerson"]}
+  attributes  => { 'givenName'    => 'Foo',
+                   'objectClass'  => ["top", "person", "inetorgPerson"]}
+                   'userPassword' => '{CRYPT}$6$ReygQlJ9xZQt.Br4$Bb0GDx9bMxTUblhlglxWlu.BU1YxpsCOrlMerl.ZRNF9a.QRBIts2PvuDVmydfMgOpGH0/Z/5gAKpRupFFBLt/' },
+  mutable     => [ 'userPassword' ],
 }
 
 ldap_entry { 'cn=Foo,ou=Bar,dc=baz,dc=co,dc=uk':
@@ -110,6 +112,10 @@ ldap_entry { 'cn=Foo,ou=Bar,dc=baz,dc=co,dc=uk':
 ```
 
 Please note that password entries need to be hashed before being passed to LDAP. You may use the puppet function `sha1digest` (see the Functions section below) or another hashing scheme such as MD5 or libcrypt. These will appear as `"{MD5}ghGY787GHvh8Uhj"` or `"{CRYPT}$6$hG7Ggh$hjhjkHUGYU67hgGt67h01hdsghGH"`, respectively.
+
+#### Attribute Mutability
+
+As demonstrated in the above example attributes can be flagged as being mutable.  This enables the provider to merely check for the existence of an attribute and ignore the actual content.  The typical use case would be to initialise the directory with default values which can then be updated by the user, in this case the _userPassword_ attribute is set to _Passw0rd_, which can then be changed at will by the user as directed by their security policy without having to update configuration management code to do so.
 
 #### Hiera example
 

--- a/lib/puppet/type/ldap_entry.rb
+++ b/lib/puppet/type/ldap_entry.rb
@@ -9,8 +9,10 @@
 #   base        => 'dc=baz,dc=co,dc=uk',
 #   username    => 'cn=admin,dc=baz,dc=co,dc=uk',
 #   password    => 'password',
-#   attributes  => { givenName   => 'Foo',
-#                    objectClass => ["top", "person", "inetorgPerson"]}
+#   attributes  => { 'givenName'    => 'Foo',
+#                    'objectClass'  => ["top", "person", "inetorgPerson"],
+#                    'userPassword' => '{CRYPT}$1$8.3a./.1$6gzjEn31TDPTeBMjAUbrE1' },
+#   mutable     => [ 'userPassword' ],
 # }
 #
 # ldap_entry { 'cn=Foo,ou=Bar,dc=baz,dc=co,dc=uk':
@@ -82,6 +84,11 @@ Puppet::Type.newtype(:ldap_entry) do
         raise ArgumentError, 'ldap_entry::attributes is not a hash'
       end
     end
+  end
+
+  newparam(:mutable) do
+    desc 'LDAP entry attribute(s) which may be externally modified'
+    defaultto []
   end
 
   newparam(:self_signed) do

--- a/spec/acceptance/server_spec.rb
+++ b/spec/acceptance/server_spec.rb
@@ -2,13 +2,28 @@ require 'spec_helper_acceptance'
 
 describe 'ldap::server class' do
 
+  suffix = 'dc=example,dc=com'
+  rootdn = 'cn=admin,dc=example,dc=com'
+  rootpw = 'llama123'
+
+  ldap_entry_defaults = <<-EOS
+    Ldap_entry {
+      host       => 'localhost',
+      port       => 389,
+      ssl        => false,
+      base       => '#{suffix}',
+      username   => '#{rootdn}',
+      password   => '#{rootpw}',
+    }
+  EOS
+
   context 'required parameters' do
     it 'should work idempotently with no errors' do
       pp = <<-EOS
         class { 'ldap::server':
-          suffix => 'dc=example,dc=com',
-          rootdn => 'cn=admin,dc=example,dc=com',
-          rootpw => 'llama123',
+          suffix => '#{suffix}',
+          rootdn => '#{rootdn}',
+          rootpw => '#{rootpw}',
         }
       EOS
 
@@ -26,4 +41,59 @@ describe 'ldap::server class' do
       it { is_expected.to be_running }
     end
   end
+
+  context 'schema' do
+    it 'should create a schema idempotently' do
+      pp = <<-EOS
+        #{ldap_entry_defaults}
+        ldap_entry { '#{suffix}':
+          attributes => {
+            'objectClass' => [
+              'dcObject',
+              'organization',
+            ],
+            'dc'          => 'example',
+            'o'           => 'example.com',
+          },
+        } ->
+        ldap_entry { 'ou=people,#{suffix}':
+          attributes => {
+            'objectClass' => [
+              'top',
+              'organizationalUnit',
+            ],
+            'ou'          => 'people',
+          },
+        }
+      EOS
+
+      apply_manifest(pp, :catch_failures => true)
+      apply_manifest(pp, :catch_changes  => true)
+    end
+  end
+
+  context 'user' do
+    it 'should create a user with mutable password idempotently' do
+      pp = <<-EOS
+        #{ldap_entry_defaults}
+        ldap_entry { 'cn=test,ou=people,#{suffix}':
+          attributes => {
+            'objectClass'  => [
+              'person',
+            ],
+            'cn'           => 'test',
+            'sn'           => 'test',
+            'userPassword' => '{CRYPT}$1$AtrY7YzK$ntxY68O7XvV6mlKy50zT31',
+          },
+          mutable    => [
+            'userPassword',
+          ],
+        }
+      EOS
+
+      apply_manifest(pp, :catch_failures => true)
+      apply_manifest(pp, :catch_changes  => true)
+    end
+  end
+
 end


### PR DESCRIPTION
Addresses Issue #64.  Adds support to declare attributes mutable allowing defaults
to be specified initially by puppet then managed independantly e.g. passwords can
be updated as PAM dictates without having to update puppet or hiera, or to explicitly
remove the attribute from the resource declaration.  There is a danger that the
semantics of this type may change in the future to remove unmanaged attributes
automatically, so by adding mutable attributes we avoid unexpectedly deleting users'
credentials.

Additionally caches the result of the ldap search performed during exists? so it
may be reused during attribute updates.