### PR TITLE
Modified datacentred-ldap Puppet module to allow for the use of mirrormode.

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -82,6 +82,7 @@ class ldap::params {
   $server_sync_bindmethod     = undef
   $server_sync_binddn         = undef
   $server_sync_credentials    = undef
+  $server_sync_mirrormode     = undef
   $server_sync_saslmech       = undef
   $server_sync_tls_cert       = undef
   $server_sync_tls_key        = undef

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -131,6 +131,9 @@
 # [*sync_credentials*]
 #   Simple bind credentials for provider.
 #
+# [*sync_mirrormode*]
+#   Enable mirror mode replication.
+#
 # [*sync_saslmech*]
 #   SASL mechanism for syncrepl replication.
 #
@@ -318,6 +321,7 @@ class ldap::server (
   $sync_bindmethod     = $ldap::params::server_sync_bindmethod,
   $sync_binddn         = $ldap::params::server_sync_binddn,
   $sync_credentials    = $ldap::params::server_sync_credentials,
+  $sync_mirrormode     = $ldap::params::server_sync_mirrormode,
   $sync_bindmethod     = $ldap::params::server_sync_bindmethod,
   $sync_saslmech       = $ldap::params::server_sync_saslmech,
   $sync_tls_cert       = $ldap::params::server_sync_tls_cert,
@@ -461,6 +465,9 @@ class ldap::server (
   }
   if $sync_credentials {
     validate_string($sync_credentials)
+  }
+  if $sync_mirrormode {
+    validate_string($sync_mirrormode)
   }
   if $slapd_services {
     validate_string($slapd_services)

--- a/templates/slapd.conf.erb
+++ b/templates/slapd.conf.erb
@@ -156,6 +156,9 @@ syncrepl
   tls_reqcert=<%= @sync_tls_reqcert %>
 <% end -%>
 
+<% if @sync_mirrormode -%>
+mirrormode <%= @sync_mirrormode %>
+<% end -%>
 updateref <%= @sync_master_uri_cfg %>
 <% end -%>
 


### PR DESCRIPTION
Allow the use of mirrormode in the replication configuration section as follows:

sync_mirrormode => 'on',

Which adds:

mirrormode on

to the slapd.conf configuration file.