### PR TITLE
Fixes for CentOS/RedHat 7

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -152,7 +152,10 @@ class ldap::params {
 
       $server_package_name       = 'openldap-servers'
       $server_service_name       = 'slapd'
-      $server_default_file       = "${os_config_directory}/ldap"
+      $server_default_file       = $::operatingsystemmajrelease ? {
+        '7'     => "${os_config_directory}/slapd",
+        default => "${os_config_directory}/ldap",
+      }
       $server_default_file_mode  = '0644'
       $server_default_template   = 'ldap/redhat/sysconfig.erb'
       $server_directory          = '/var/lib/ldap'

--- a/templates/redhat/sysconfig.erb
+++ b/templates/redhat/sysconfig.erb
@@ -1,35 +1,25 @@
-# Options of slapd (see man slapd)
-SLAPD_OPTIONS='-f <%= @config_file %>'
+# OpenLDAP server configuration
+# see 'man slapd' for additional information
 
-# At least one of SLAPD_LDAP, SLAPD_LDAPI and SLAPD_LDAPS must be set to 'yes'!
-#
-# Run slapd with -h "... ldap:/// ..."
-#   yes/no, default: yes
-SLAPD_LDAP=yes
-
-# Run slapd with -h "... ldapi:/// ..."
-#   yes/no, default: yes
-SLAPD_LDAPI=yes
-
-# Run slapd with -h "... ldaps:/// ..."
-#   yes/no, default: no
-<% if @ssl -%>
-SLAPD_LDAPS=yes
+# Where the server will run (-h option)
+# - ldapi:/// is required for on-the-fly configuration using client tools
+#   (use SASL with EXTERNAL mechanism for authentication)
+# - default: ldapi:/// ldap:///
+# - example: ldapi:/// ldap://127.0.0.1/ ldap://10.0.0.1:1389/ ldaps:///
+<% if @slapd_services -%>
+SLAPD_URLS="<%= @slapd_services %>"
 <% else -%>
-SLAPD_LDAPS=no
+<%    if @ssl -%>
+SLAPD_URLS="ldap:/// ldaps:/// ldapi:///"
+<%    else -%>
+SLAPD_URLS="ldap:/// ldapi:///"
+<%    end -%>
 <% end -%>
 
-# Run slapd with -h "... $SLAPD_URLS ..."
-# This option could be used instead of previous three ones, but:
-# - it doesn't overwrite settings of $SLAPD_LDAP, $SLAPD_LDAPS and $SLAPD_LDAPI options
-# - it isn't overwritten by settings of $SLAPD_LDAP, $SLAPD_LDAPS and $SLAPD_LDAPI options
-# example: SLAPD_URLS="ldapi:///var/lib/ldap_root/ldapi ldapi:/// ldaps:///"
-# default: empty
-#SLAPD_URLS=""
+# Any custom options
+#SLAPD_OPTIONS=""
+SLAPD_OPTIONS='-f <%= @config_file %>'
 
-# Maximum allowed time to wait for slapd shutdown on 'service ldap stop' (in seconds)
-#SLAPD_SHUTDOWN_TIMEOUT=3
-
-# Parameters to ulimit, use to change system limits for slapd
-#SLAPD_ULIMIT_SETTINGS=""
+# Keytab location for GSSAPI Kerberos authentication
+#KRB5_KTNAME="FILE:/etc/openldap/ldap.keytab"
 


### PR DESCRIPTION
- Newer versions of OpenLDAP ignore the SLAPD_LDAP / SLAPD_LDAP / SLAPD_LDAPI setting, so use SLAPD_URLS instead.
- The server_default_file in CentOS 7 is slapd