### PR TITLE
FIX ERROR: Parameter sync_bindmethod is declared more than once

### DIFF
--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -322,7 +322,6 @@ class ldap::server (
   $sync_binddn         = $ldap::params::server_sync_binddn,
   $sync_credentials    = $ldap::params::server_sync_credentials,
   $sync_mirrormode     = $ldap::params::server_sync_mirrormode,
-  $sync_bindmethod     = $ldap::params::server_sync_bindmethod,
   $sync_saslmech       = $ldap::params::server_sync_saslmech,
   $sync_tls_cert       = $ldap::params::server_sync_tls_cert,
   $sync_tls_key        = $ldap::params::server_sync_tls_key,


### PR DESCRIPTION
just ran into that one:

Error: Could not retrieve catalog from remote server: Error 400 on SERVER: The parameter 'sync_bindmethod' is declared more than once in the parameter list at /etc/puppet/environments/production/modules/ldap/manifests/server.pp:325:3 on node ...