### PR TITLE
Support for Puppet 4+

### DIFF
--- a/manifests/client/install.pp
+++ b/manifests/client/install.pp
@@ -9,14 +9,23 @@ class ldap::client::install inherits ldap::client {
   }
 
   if $ldap::client::manage_package_dependencies {
-    package { 'ruby':
-      ensure => present,
-    } ->
 
-    package { 'net-ldap':
-      ensure   => $ldap::client::net_ldap_package_ensure,
-      name     => $ldap::client::net_ldap_package_name,
-      provider => $ldap::client::net_ldap_package_provider,
+    if versioncmp($::puppetversion, '4.0.0') > 0 {
+
+      # Puppet 4 has its own self-contained ruby environment so install the
+      # requisite packages there
+      exec { '/opt/puppetlabs/puppet/bin/gem install net-ldap':
+        unless => '/opt/puppetlabs/puppet/bin/gem list | grep net-ldap',
+      }
+
+    } else {
+
+      package { 'net-ldap':
+        ensure   => $ldap::client::net_ldap_package_ensure,
+        name     => $ldap::client::net_ldap_package_name,
+        provider => $ldap::client::net_ldap_package_provider,
+      }
+
     }
   }
 }


### PR DESCRIPTION
Using the major version of puppet running we install the net-ldap gem a bit
differently on puppet 4.  PC1 comes with its own ruby environment in
/opt/puppetlabs/puppet so we need to install the gem with the packaged gem
binary which will install it into a location puppet can find.