### PR TITLE
Add ability to set service flags for OpenBSD. 

### DIFF
--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -89,6 +89,9 @@
 # [*refint_attributes*]
 #   Attributes for refint overlay.
 #
+# [*service_flags*]
+#   Flags that steer the service parameters, only useful for OpenBSD, defaults to 'undef'.
+#
 # [*sync_rid*]
 #   Replication ID to use for syncrepl replication.
 #
@@ -350,6 +353,7 @@ class ldap::server (
   $package_ensure   = $ldap::params::server_package_ensure,
   $service_manage   = $ldap::params::server_service_manage,
   $service_name     = $ldap::params::server_service_name,
+  $service_flags    = undef,
   $service_enable   = $ldap::params::server_service_enable,
   $service_ensure   = $ldap::params::server_service_ensure,
   $config_directory = $ldap::params::ldap_config_directory,

--- a/manifests/server/service.pp
+++ b/manifests/server/service.pp
@@ -4,12 +4,26 @@
 #
 class ldap::server::service inherits ldap::server {
   if $ldap::server::service_manage == true {
-    service { 'ldap-server':
-      ensure     => $ldap::server::service_ensure,
-      enable     => $ldap::server::service_enable,
-      name       => $ldap::server::service_name,
-      hasstatus  => true,
-      hasrestart => true,
+    # Puppet versions prior 3.6 did not have the
+    # flags parameter, and Ruby versions < 2 seem to
+    # be problematic in general with that parameter
+    if $::osfamily == 'OpenBSD' {
+      service { 'ldap-server':
+        ensure     => $ldap::server::service_ensure,
+        enable     => $ldap::server::service_enable,
+        name       => $ldap::server::service_name,
+        flags      => $ldap::server::service_flags,
+        hasstatus  => true,
+        hasrestart => true,
+      }
+    } else {
+      service { 'ldap-server':
+        ensure     => $ldap::server::service_ensure,
+        enable     => $ldap::server::service_enable,
+        name       => $ldap::server::service_name,
+        hasstatus  => true,
+        hasrestart => true,
+      }
     }
   }
 }


### PR DESCRIPTION
This is necessary, to actually tell the server to listen on LDAPs or only listen on
localhost. Defaults to undef.

exaple Hiera entry to tell it to listen only on localhost, plain
ldap as well as ldaps:

ldap::server::service_flags: '-u _openldap -h ldap://localhost\ ldaps://localhost'

Guard the usage of the 'flags' service parameter with a
if statement, testing for ::osfamily == 'OpenBSD'
The 'flags' parameter got added with Puppet 3.6.X and
with Ruby versions < 2.X it also seems to be problematic
as the spec tests show
