### PR TITLE
Fix return value of exists? in ldap_entry provider.

### DIFF
--- a/lib/puppet/provider/ldap_entry/ldap.rb
+++ b/lib/puppet/provider/ldap_entry/ldap.rb
@@ -26,6 +26,7 @@ Puppet::Type.type(:ldap_entry).provide(:ldap) do
         end
         return matching
       end
+      return nil if results.empty?
     else
       raise "LDAP Error #{status}: #{results}. Check server log for more info."
     end


### PR DESCRIPTION
In the event where a search was successful but there were no matching
entries, `exists?` was returning an incorrect value. This resulted in
`ensure` not having the desired effect.

This commit fixes this by returning `nil` if the search was successful
but the results set is empty.