### PR TITLE
Add support for FreeBSD platform

### DIFF
--- a/manifests/client/install.pp
+++ b/manifests/client/install.pp
@@ -8,24 +8,33 @@ class ldap::client::install inherits ldap::client {
     name   => $ldap::client::package_name,
   }
 
-  if $ldap::client::manage_package_dependencies {
 
-    if versioncmp($::puppetversion, '4.0.0') > 0 {
-
-      # Puppet 4 has its own self-contained ruby environment so install the
-      # requisite packages there
-      exec { '/opt/puppetlabs/puppet/bin/gem install net-ldap':
-        unless => '/opt/puppetlabs/puppet/bin/gem list | grep net-ldap',
+  case $::osfamily {
+    'FreeBSD': {
+      if $ldap::client::manage_package_dependencies {
+        package { 'net-ldap':
+          ensure   => $ldap::client::net_ldap_package_ensure,
+          name     => $ldap::client::net_ldap_package_name,
+          provider => $ldap::client::net_ldap_package_provider,
+        }
       }
+    }
+    default: {
+      if versioncmp($::puppetversion, '4.0.0') > 0 {
 
-    } else {
+        # Puppet 4 has its own self-contained ruby environment so install the
+        # requisite packages there
+        exec { '/opt/puppetlabs/puppet/bin/gem install net-ldap':
+          unless => '/opt/puppetlabs/puppet/bin/gem list | grep net-ldap',
+        }
 
-      package { 'net-ldap':
-        ensure   => $ldap::client::net_ldap_package_ensure,
-        name     => $ldap::client::net_ldap_package_name,
-        provider => $ldap::client::net_ldap_package_provider,
+      } else {
+        package { 'net-ldap':
+          ensure   => $ldap::client::net_ldap_package_ensure,
+          name     => $ldap::client::net_ldap_package_name,
+          provider => $ldap::client::net_ldap_package_provider,
+        }
       }
-
     }
   }
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -137,8 +137,8 @@ class ldap::params {
       $server_default_template   = undef
       $server_directory          = '/var/openldap-data'
       $server_directory_mode     = '0700'
-      $net_ldap_package_name     = 'net-ldap'
-      $net_ldap_package_provider = 'gem'
+      $net_ldap_package_name     = 'rubygem-net-ldap'
+      $net_ldap_package_provider = 'pkgng'
     }
     'OpenBSD': {
       $ldap_config_directory     = '/etc/openldap'

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -23,7 +23,6 @@ class ldap::params {
   $server_service_ensure      = 'running'
   $server_service_manage      = true
   $server_config_template     = 'ldap/slapd.conf.erb'
-  $server_backend             = 'bdb'
 
   $server_log_level = 'none'
 
@@ -100,6 +99,7 @@ class ldap::params {
     'Debian': {
       $ldap_config_directory     = '/etc/ldap'
       $os_config_directory       = '/etc/default'
+      $server_backend            = 'bdb'
       $server_run_directory      = '/var/run/slapd'
       $server_run_directory_mode = '0700'
 
@@ -118,9 +118,32 @@ class ldap::params {
       $net_ldap_package_name     = 'ruby-net-ldap'
       $net_ldap_package_provider = 'apt'
     }
+    'FreeBSD': {
+      $ldap_config_directory     = '/usr/local/etc/openldap'
+      $os_config_directory       = undef
+      $server_backend            = 'mdb'
+      $server_run_directory      = '/var/run/openldap'
+      $server_run_directory_mode = '0755'
+
+      $client_package_name       = 'openldap-client'
+
+      $ldapowner                 = 'ldap'
+      $ldapgroup                 = 'ldap'
+
+      $server_package_name       = 'openldap-server'
+      $server_service_name       = 'slapd'
+      $server_default_file       = undef
+      $server_default_file_mode  = undef
+      $server_default_template   = undef
+      $server_directory          = '/var/openldap-data'
+      $server_directory_mode     = '0700'
+      $net_ldap_package_name     = 'net-ldap'
+      $net_ldap_package_provider = 'gem'
+    }
     'OpenBSD': {
       $ldap_config_directory     = '/etc/openldap'
       $os_config_directory       = undef
+      $server_backend            = 'bdb'
       $server_run_directory      = '/var/run/openldap'
       $server_run_directory_mode = '0755'
 
@@ -142,6 +165,7 @@ class ldap::params {
     'RedHat': {
       $ldap_config_directory     = '/etc/openldap'
       $os_config_directory       = '/etc/sysconfig'
+      $server_backend            = 'bdb'
       $server_run_directory      = '/var/run/openldap'
       $server_run_directory_mode = '0700'
 

--- a/metadata.json
+++ b/metadata.json
@@ -28,6 +28,13 @@
       ]
     },
     {
+      "operatingsystem": "FreeBSD",
+      "operatingsystemrelease": [
+        "11",
+        "12"
+      ]
+    },
+    {
       "operatingsystem": "Ubuntu",
       "operatingsystemrelease": [
         "14.04"


### PR DESCRIPTION
Split **server_backend** variables and set to 'mdb' by default for FreeBSD, since Berkley DB back-end is deprecated and removed (  less -p 20140318 /usr/ports/UPDATING )
