### PR TITLE
Enable net-ldap version logic for agent versions 5 and 6.

### DIFF
--- a/manifests/client/install.pp
+++ b/manifests/client/install.pp
@@ -20,14 +20,15 @@ class ldap::client::install inherits ldap::client {
       }
     }
     default: {
-      if versioncmp($::puppetversion, '4.0.0') > 0 {
-
-        # Puppet 4 has its own self-contained ruby environment so install the
+      if (
+        (versioncmp($::puppetversion, '4.0.0') > 0) or
+        (versioncmp($::puppetversion, '5.0.0') > 0) or
+        (versioncmp($::puppetversion, '6.0.0') > 0)){
+        # Puppet 4/5/6 has its own self-contained ruby environment so install the
         # requisite packages there
         exec { '/opt/puppetlabs/puppet/bin/gem install net-ldap':
           unless => '/opt/puppetlabs/puppet/bin/gem list | grep net-ldap',
         }
-
       } else {
         package { 'net-ldap':
           ensure   => $ldap::client::net_ldap_package_ensure,


### PR DESCRIPTION
Enable net-ldap version logic for puppet agent versions 5 and 6.